### PR TITLE
[1218] add access control

### DIFF
--- a/contracts/QuestFactory.sol
+++ b/contracts/QuestFactory.sol
@@ -7,15 +7,19 @@ import {Erc1155Quest} from './Erc1155Quest.sol';
 import {RabbitHoleReceipt} from './RabbitHoleReceipt.sol';
 import {OwnableUpgradeable} from '@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol';
 import '@openzeppelin/contracts-upgradeable/utils/cryptography/ECDSAUpgradeable.sol';
+import '@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol';
 
-contract QuestFactory is Initializable, OwnableUpgradeable {
+contract QuestFactory is Initializable, OwnableUpgradeable, AccessControlUpgradeable {
     error QuestIdUsed();
     error OverMaxAllowedToMint();
     error AddressNotSigned();
     error AddressAlreadyMinted();
     error InvalidHash();
+    error InavlidRoleToCreateQuest();
 
     event QuestCreated(address indexed creator, address indexed contractAddress, string contractType);
+
+    bytes32 public constant CREATE_QUEST_ROLE = keccak256("CREATE_QUEST_ROLE");
 
     // storage vars. Insert new vars at the end to keep the storage layout the same.
     address public claimSignerAddress;
@@ -31,6 +35,8 @@ contract QuestFactory is Initializable, OwnableUpgradeable {
 
     function initialize(address claimSignerAddress_, address rabbitholeReceiptContract_) public initializer {
         __Ownable_init();
+        __AccessControl_init();
+        grantDefaultAdminAndCreateQuestRole();
         claimSignerAddress = claimSignerAddress_;
         rabbitholeReceiptContract = RabbitHoleReceipt(rabbitholeReceiptContract_);
     }
@@ -45,7 +51,9 @@ contract QuestFactory is Initializable, OwnableUpgradeable {
         string memory contractType_,
         string memory questId_,
         address receiptContractAddress_
-    ) public onlyOwner returns (address) {
+    ) public returns (address) {
+        if (!hasRole(CREATE_QUEST_ROLE, msg.sender)) revert InavlidRoleToCreateQuest();
+
         if (questAddressForQuestId[questId_] != address(0)) revert QuestIdUsed();
 
         if (keccak256(abi.encodePacked(contractType_)) == keccak256(abi.encodePacked('erc20'))) {
@@ -89,6 +97,19 @@ contract QuestFactory is Initializable, OwnableUpgradeable {
         return address(0);
     }
 
+    function grantCreateQuestRole(address account_) public {
+        _grantRole(CREATE_QUEST_ROLE, account_);
+    }
+
+    function revokeCreateQuestRole(address account_) public {
+        _revokeRole(CREATE_QUEST_ROLE, account_);
+    }
+
+    function grantDefaultAdminAndCreateQuestRole() public onlyOwner {
+        _grantRole(DEFAULT_ADMIN_ROLE, msg.sender);
+        _grantRole(CREATE_QUEST_ROLE, msg.sender);
+    }
+
     function setClaimSignerAddress(address claimSignerAddress_) public onlyOwner {
         claimSignerAddress = claimSignerAddress_;
     }
@@ -106,7 +127,7 @@ contract QuestFactory is Initializable, OwnableUpgradeable {
         return ECDSAUpgradeable.recover(messageDigest, signature);
     }
 
-    // need to set this contract as Minter on the receipt contract.
+    // This contract must be set as Minter on the receipt contract.
     function mintReceipt(uint amount_, string memory questId_, bytes32 hash_, bytes memory signature_) public {
         if (amountMintedForQuestId[questId_] + amount_ > totalAmountForQuestId[questId_]) revert OverMaxAllowedToMint();
         if (addressMintedForQuestId[questId_][msg.sender] == true) revert AddressAlreadyMinted();

--- a/contracts/QuestFactory.sol
+++ b/contracts/QuestFactory.sol
@@ -51,9 +51,7 @@ contract QuestFactory is Initializable, OwnableUpgradeable, AccessControlUpgrade
         string memory contractType_,
         string memory questId_,
         address receiptContractAddress_
-    ) public returns (address) {
-        if (!hasRole(CREATE_QUEST_ROLE, msg.sender)) revert InavlidRoleToCreateQuest();
-
+    ) public onlyRole(CREATE_QUEST_ROLE) returns (address) {
         if (questAddressForQuestId[questId_] != address(0)) revert QuestIdUsed();
 
         if (keccak256(abi.encodePacked(contractType_)) == keccak256(abi.encodePacked('erc20'))) {

--- a/test/QuestFactory.spec.ts
+++ b/test/QuestFactory.spec.ts
@@ -159,7 +159,7 @@ describe('QuestFactory', () => {
           erc20QuestId,
           deployedRabbitHoleReceiptContract.address
         )
-      ).to.be.revertedWithCustomError(questFactoryContract, 'InavlidRoleToCreateQuest')
+      ).to.be.revertedWith(`AccessControl: account ${royaltyRecipient.address.toLowerCase()} is missing role 0xf9ca453be4e83785e69957dffc5e557020ebe7df32422c6d32ccad977982cadd`)
     })
   })
 

--- a/test/QuestFactory.spec.ts
+++ b/test/QuestFactory.spec.ts
@@ -120,8 +120,19 @@ describe('QuestFactory', () => {
     })
 
     it('Should revert if trying to use existing quest id', async () => {
-      expect(
-        await deployedFactoryContract.createQuest(
+      await deployedFactoryContract.createQuest(
+        deployedSampleErc20Contract.address,
+        expiryDate,
+        startDate,
+        totalRewards,
+        allowList,
+        rewardAmount,
+        'erc20',
+        erc20QuestId,
+        deployedRabbitHoleReceiptContract.address);
+
+      await expect(
+        deployedFactoryContract.createQuest(
           deployedSampleErc20Contract.address,
           expiryDate,
           startDate,
@@ -133,19 +144,22 @@ describe('QuestFactory', () => {
           deployedRabbitHoleReceiptContract.address
         )
       ).to.be.revertedWithCustomError(questFactoryContract, 'QuestIdUsed')
-      expect(
-        await deployedFactoryContract.createQuest(
+    })
+
+    it('Should revert if msg.sender does not have correct role', async () => {
+      await expect(
+        deployedFactoryContract.connect(royaltyRecipient).createQuest(
           deployedSampleErc20Contract.address,
           expiryDate,
           startDate,
           totalRewards,
           allowList,
           rewardAmount,
-          'erc1155',
-          erc1155QuestId,
+          'erc20',
+          erc20QuestId,
           deployedRabbitHoleReceiptContract.address
         )
-      ).to.be.revertedWithCustomError(questFactoryContract, 'QuestIdUsed')
+      ).to.be.revertedWithCustomError(questFactoryContract, 'InavlidRoleToCreateQuest')
     })
   })
 


### PR DESCRIPTION
Adds access control to the `createQuest` function, along with the `CREATE_QUEST_ROLE`.

Note: we will need to do a one time call of the `grantDefaultAdminAndCreateQuestRole` function to give the admin access role to the owner.