### PR TITLE
Remove quantity in minting receipts, change protocolFee math, spec updates and some refactorings

### DIFF
--- a/contracts/Erc1155Quest.sol
+++ b/contracts/Erc1155Quest.sol
@@ -34,13 +34,6 @@ contract Erc1155Quest is Quest, ERC1155Holder {
         super.start();
     }
 
-    function claim() public override returns (uint256) {
-        if (IERC1155(rewardToken).balanceOf(address(this), rewardAmountInWeiOrTokenId) < totalParticipants)
-            revert AmountExceedsBalance();
-        super.claim();
-        return rewardAmountInWeiOrTokenId; // not used
-    }
-
     function _transferRewards(uint256 amount_) internal override {
         IERC1155(rewardToken).safeTransferFrom(address(this), msg.sender, rewardAmountInWeiOrTokenId, amount_, '0x00');
     }

--- a/contracts/Erc1155Quest.sol
+++ b/contracts/Erc1155Quest.sol
@@ -10,7 +10,7 @@ contract Erc1155Quest is Quest, ERC1155Holder {
         address rewardTokenAddress_,
         uint256 endTime_,
         uint256 startTime_,
-        uint256 totalAmount_,
+        uint256 totalParticipants_,
         string memory allowList_,
         uint256 rewardAmountInWeiOrTokenId_,
         string memory questId_,
@@ -20,7 +20,7 @@ contract Erc1155Quest is Quest, ERC1155Holder {
         rewardTokenAddress_,
         endTime_,
         startTime_,
-        totalAmount_,
+        totalParticipants_,
         allowList_,
         rewardAmountInWeiOrTokenId_,
         questId_,
@@ -29,15 +29,16 @@ contract Erc1155Quest is Quest, ERC1155Holder {
     {}
 
     function start() public override {
-        if (IERC1155(rewardToken).balanceOf(address(this), rewardAmountInWeiOrTokenId) < totalAmount)
+        if (IERC1155(rewardToken).balanceOf(address(this), rewardAmountInWeiOrTokenId) < totalParticipants)
             revert TotalAmountExceedsBalance();
         super.start();
     }
 
-    function claim() public override {
-        if (IERC1155(rewardToken).balanceOf(address(this), rewardAmountInWeiOrTokenId) < totalAmount)
+    function claim() public override returns (uint256) {
+        if (IERC1155(rewardToken).balanceOf(address(this), rewardAmountInWeiOrTokenId) < totalParticipants)
             revert AmountExceedsBalance();
         super.claim();
+        return rewardAmountInWeiOrTokenId; // not used
     }
 
     function _transferRewards(uint256 amount_) internal override {
@@ -48,11 +49,11 @@ contract Erc1155Quest is Quest, ERC1155Holder {
         return redeemableTokenCount_;
     }
 
-    function withdrawRemainingTokens() public override onlyOwner {
-        super.withdrawRemainingTokens();
+    function withdrawRemainingTokens(address to_) public override onlyOwner {
+        super.withdrawRemainingTokens(to_);
         IERC1155(rewardToken).safeTransferFrom(
             address(this),
-            msg.sender,
+            to_,
             rewardAmountInWeiOrTokenId,
             IERC1155(rewardToken).balanceOf(address(this), rewardAmountInWeiOrTokenId),
             '0x00'

--- a/contracts/Erc20Quest.sol
+++ b/contracts/Erc20Quest.sol
@@ -53,13 +53,6 @@ contract Erc20Quest is Quest {
         super.start();
     }
 
-    function claim() public override returns (uint256) {
-        uint redeemableTokenCount = super.claim();
-        reedemedTokens += redeemableTokenCount;
-
-        return redeemableTokenCount; // not used
-    }
-
     function _transferRewards(uint256 amount_) internal override {
         IERC20(rewardToken).safeTransfer(msg.sender, amount_);
     }

--- a/contracts/Erc20Quest.sol
+++ b/contracts/Erc20Quest.sol
@@ -77,7 +77,7 @@ contract Erc20Quest is Quest {
     }
 
     function receiptRedeemers() public view returns (uint256) {
-        return questFactoryContract.numberMintedForQuestId(questId);
+        return questFactoryContract.getNumberMinted(questId);
     }
 
     function protocolFee() public view returns (uint256) {

--- a/contracts/Erc20Quest.sol
+++ b/contracts/Erc20Quest.sol
@@ -16,7 +16,7 @@ contract Erc20Quest is Quest {
         address rewardTokenAddress_,
         uint256 endTime_,
         uint256 startTime_,
-        uint256 totalAmount_,
+        uint256 totalParticipants_,
         string memory allowList_,
         uint256 rewardAmountInWeiOrTokenId_,
         string memory questId_,
@@ -29,38 +29,41 @@ contract Erc20Quest is Quest {
         rewardTokenAddress_,
         endTime_,
         startTime_,
-        totalAmount_,
+        totalParticipants_,
         allowList_,
         rewardAmountInWeiOrTokenId_,
         questId_,
         receiptContractAddress_
     ) {
         questFee = questFee_;
-        totalRedeemers = rewardAmountInWeiOrTokenId / totalAmount;
+        totalRedeemers = totalParticipants / rewardAmountInWeiOrTokenId_;
         protocolFeeRecipient = protocolFeeRecipient_;
         questFactoryContract = QuestFactory(factoryContractAddress_);
         factoryContractAddress = factoryContractAddress_;
     }
 
+    function questFeePercentage() public view returns (uint256) {
+        return questFee / 10_000;
+    }
+
+    function maxTotalRewards() public view returns (uint256) {
+        return totalParticipants * rewardAmountInWeiOrTokenId;
+    }
+
+    function maxProtocolReward() public view returns (uint256) {
+        return maxTotalRewards() * questFeePercentage();
+    }
+
     function start() public override {
-        if (IERC20(rewardToken).balanceOf(address(this)) < (totalAmount + (totalAmount * questFee / 10_000))) revert TotalAmountExceedsBalance();
+        if (IERC20(rewardToken).balanceOf(address(this)) < maxTotalRewards() + maxProtocolReward()) revert TotalAmountExceedsBalance();
         super.start();
     }
 
-    function mintReceipt(uint amount_, string memory questId_, bytes32 hash_, bytes memory signature_) public {
-        if (hasStarted == false) revert NotStarted();
-        if (isPaused == true) revert QuestPaused();
-        if (block.timestamp < startTime) revert NotStarted();
-        if (block.timestamp > endTime) revert QuestEnded();
+    function claim() public override returns (uint256) {
+        uint redeemableTokenCount = super.claim();
+        reedemedTokens += redeemableTokenCount;
 
-        questFactoryContract.mintReceipt(amount_, questId_, hash_, signature_);
-        receiptRedeemers ++;
-    }
-
-    function claim() public override {
-        if (IERC20(rewardToken).balanceOf(address(this)) < (rewardAmountInWeiOrTokenId * questFee / 10_000)) revert AmountExceedsBalance();
-        super.claim();
-        rewardRedeemers++;
+        return redeemableTokenCount; // not used
     }
 
     function _transferRewards(uint256 amount_) internal override {
@@ -71,15 +74,25 @@ contract Erc20Quest is Quest {
         return redeemableTokenCount_ * rewardAmountInWeiOrTokenId;
     }
 
-    function withdrawRemainingTokens() public override onlyOwner {
-        super.withdrawRemainingTokens();
+    function withdrawRemainingTokens(address to_) public override onlyOwner {
+        super.withdrawRemainingTokens(to_);
 
-        uint256 nonClaimableTokens = (totalRedeemers - receiptRedeemers) * rewardAmountInWeiOrTokenId;
-        IERC20(rewardToken).safeTransfer(msg.sender, nonClaimableTokens);
+        uint unclaimedTokens = (receiptRedeemers() - reedemedTokens) * rewardAmountInWeiOrTokenId;
+        uint256 nonClaimableTokens = IERC20(rewardToken).balanceOf(address(this)) - protocolFee() - unclaimedTokens;
+        IERC20(rewardToken).safeTransfer(to_, nonClaimableTokens);
     }
 
-    function withdrawFee() public {
-        IERC20(rewardToken).safeTransfer(protocolFeeRecipient, (receiptRedeemers * rewardAmountInWeiOrTokenId * questFee / 10_000));
+    function receiptRedeemers() public view returns (uint256) {
+        return questFactoryContract.numberMintedForQuestId(questId);
+    }
+
+    // 1 * 1 * 0.2 = 0.2
+    function protocolFee() public view returns (uint256) {
+        return receiptRedeemers() * rewardAmountInWeiOrTokenId * questFeePercentage();
+    }
+
+    function withdrawFee() public onlyStarted {
+        IERC20(rewardToken).safeTransfer(protocolFeeRecipient, protocolFee());
     }
 }
 

--- a/contracts/Erc20Quest.sol
+++ b/contracts/Erc20Quest.sol
@@ -42,16 +42,12 @@ contract Erc20Quest is Quest {
         factoryContractAddress = factoryContractAddress_;
     }
 
-    function questFeePercentage() public view returns (uint256) {
-        return questFee / 10_000;
-    }
-
     function maxTotalRewards() public view returns (uint256) {
         return totalParticipants * rewardAmountInWeiOrTokenId;
     }
 
     function maxProtocolReward() public view returns (uint256) {
-        return maxTotalRewards() * questFeePercentage();
+        return maxTotalRewards() * questFee / 10_000;
     }
 
     function start() public override {
@@ -87,7 +83,7 @@ contract Erc20Quest is Quest {
     }
 
     function protocolFee() public view returns (uint256) {
-        return receiptRedeemers() * rewardAmountInWeiOrTokenId * 2000 / 10000;
+        return receiptRedeemers() * rewardAmountInWeiOrTokenId * questFee / 10_000;
     }
 
     function withdrawFee() public onlyStarted {

--- a/contracts/Erc20Quest.sol
+++ b/contracts/Erc20Quest.sol
@@ -8,7 +8,6 @@ import {QuestFactory} from './QuestFactory.sol';
 contract Erc20Quest is Quest {
     using SafeERC20 for IERC20;
     uint256 public questFee;
-    uint256 public totalRedeemers;
     address public protocolFeeRecipient;
     QuestFactory public questFactoryContract;
 
@@ -36,7 +35,6 @@ contract Erc20Quest is Quest {
         receiptContractAddress_
     ) {
         questFee = questFee_;
-        totalRedeemers = totalParticipants / rewardAmountInWeiOrTokenId_;
         protocolFeeRecipient = protocolFeeRecipient_;
         questFactoryContract = QuestFactory(factoryContractAddress_);
         factoryContractAddress = factoryContractAddress_;

--- a/contracts/Erc20Quest.sol
+++ b/contracts/Erc20Quest.sol
@@ -86,9 +86,8 @@ contract Erc20Quest is Quest {
         return questFactoryContract.numberMintedForQuestId(questId);
     }
 
-    // 1 * 1 * 0.2 = 0.2
     function protocolFee() public view returns (uint256) {
-        return receiptRedeemers() * rewardAmountInWeiOrTokenId * questFeePercentage();
+        return receiptRedeemers() * rewardAmountInWeiOrTokenId * 2000 / 10000;
     }
 
     function withdrawFee() public onlyStarted {

--- a/contracts/Quest.sol
+++ b/contracts/Quest.sol
@@ -76,7 +76,7 @@ contract Quest is Ownable, IQuest {
         _;
     }
 
-    function claim() public virtual onlyStarted returns (uint256) {
+    function claim() public virtual onlyStarted {
         if (isPaused == true) revert QuestPaused();
 
         uint[] memory tokens = rabbitHoleReceiptContract.getOwnedTokenIdsOfQuest(questId, msg.sender);
@@ -84,7 +84,6 @@ contract Quest is Ownable, IQuest {
         if (tokens.length == 0) revert NoTokensToClaim();
 
         uint256 redeemableTokenCount = 0;
-
         for (uint i = 0; i < tokens.length; i++) {
             if (!isClaimed(tokens[i])) {
                 redeemableTokenCount++;
@@ -94,14 +93,11 @@ contract Quest is Ownable, IQuest {
         if (redeemableTokenCount == 0) revert AlreadyClaimed();
 
         uint256 totalReedemableRewards = _calculateRewards(redeemableTokenCount);
-
         _setClaimed(tokens);
-
         _transferRewards(totalReedemableRewards);
+        reedemedTokens += redeemableTokenCount;
 
         emit Claimed(msg.sender, totalReedemableRewards);
-
-        return redeemableTokenCount;
     }
 
     function _calculateRewards(uint256 redeemableTokenCount_) internal virtual returns (uint256) {

--- a/contracts/Quest.sol
+++ b/contracts/Quest.sol
@@ -12,15 +12,13 @@ contract Quest is Ownable, IQuest {
     address public factoryContractAddress;
     uint256 public endTime;
     uint256 public startTime;
-    uint256 public totalAmount;
+    uint256 public totalParticipants;
     uint256 public rewardAmountInWeiOrTokenId;
     bool public hasStarted;
     bool public isPaused;
     string public allowList;
     string public questId;
-    uint256 public receiptRedeemers;
-    uint256 public rewardRedeemers;
-
+    uint256 public reedemedTokens;
 
     mapping(uint256 => bool) private claimedList;
 
@@ -28,7 +26,7 @@ contract Quest is Ownable, IQuest {
         address rewardTokenAddress_,
         uint256 endTime_,
         uint256 startTime_,
-        uint256 totalAmount_,
+        uint256 totalParticipants_,
         string memory allowList_,
         uint256 rewardAmountInWeiOrTokenId_,
         string memory questId_,
@@ -39,13 +37,12 @@ contract Quest is Ownable, IQuest {
         endTime = endTime_;
         startTime = startTime_;
         rewardToken = rewardTokenAddress_;
-        totalAmount = totalAmount_;
+        totalParticipants = totalParticipants_;
         rewardAmountInWeiOrTokenId = rewardAmountInWeiOrTokenId_;
         allowList = allowList_;
         questId = questId_;
         rabbitHoleReceiptContract = RabbitHoleReceipt(receiptContractAddress_);
-        receiptRedeemers = 0;
-        rewardRedeemers = 0;
+        reedemedTokens = 0;
     }
 
     function start() public virtual onlyOwner {
@@ -73,10 +70,14 @@ contract Quest is Ownable, IQuest {
         }
     }
 
-    function claim() public virtual {
+    modifier onlyStarted() {
         if (hasStarted == false) revert NotStarted();
-        if (isPaused == true) revert QuestPaused();
         if (block.timestamp < startTime) revert ClaimWindowNotStarted();
+        _;
+    }
+
+    function claim() public virtual onlyStarted returns (uint256) {
+        if (isPaused == true) revert QuestPaused();
 
         uint[] memory tokens = rabbitHoleReceiptContract.getOwnedTokenIdsOfQuest(questId, msg.sender);
 
@@ -99,6 +100,8 @@ contract Quest is Ownable, IQuest {
         _transferRewards(totalReedemableRewards);
 
         emit Claimed(msg.sender, totalReedemableRewards);
+
+        return redeemableTokenCount;
     }
 
     function _calculateRewards(uint256 redeemableTokenCount_) internal virtual returns (uint256) {
@@ -113,7 +116,7 @@ contract Quest is Ownable, IQuest {
         return claimedList[tokenId_] && claimedList[tokenId_] == true;
     }
 
-    function withdrawRemainingTokens() public virtual onlyOwner {
+    function withdrawRemainingTokens(address to_) public virtual onlyOwner {
         if (block.timestamp < endTime) revert NoWithdrawDuringClaim();
     }
 }

--- a/contracts/QuestFactory.sol
+++ b/contracts/QuestFactory.sol
@@ -30,6 +30,7 @@ contract QuestFactory is Initializable, OwnableUpgradeable, AccessControlUpgrade
     RabbitHoleReceipt public rabbitholeReceiptContract;
     mapping(string => mapping(address => bool)) public addressMintedForQuestId;
     address public protocolFeeRecipient;
+    mapping(string => uint256) public numberMintedForQuestId;
 
     // always be initialized
     /// @custom:oz-upgrades-unsafe-allow constructor
@@ -150,6 +151,7 @@ contract QuestFactory is Initializable, OwnableUpgradeable, AccessControlUpgrade
 
         amountMintedForQuestId[questId_] += amount_;
         addressMintedForQuestId[questId_][msg.sender] = true;
+        numberMintedForQuestId[questId_]++;
         rabbitholeReceiptContract.mint(msg.sender, amount_, questId_);
     }
 }

--- a/contracts/RabbitHoleReceipt.sol
+++ b/contracts/RabbitHoleReceipt.sol
@@ -65,18 +65,12 @@ contract RabbitHoleReceipt is
         royaltyFee = _royaltyFee;
     }
 
-    function _mintSingleNFT(address _to, string memory _questId) private {
+    function mint(address _to, string memory _questId) public onlyMinter {
         _tokenIds.increment();
         uint newTokenID = _tokenIds.current();
         _safeMint(_to, newTokenID);
         questIdForTokenId[newTokenID] = _questId;
         timestampForTokenId[newTokenID] = block.timestamp;
-    }
-
-    function mint(address _to, uint _count, string memory _questId) public onlyMinter {
-        for (uint i = 0; i < _count; i++) {
-            _mintSingleNFT(_to, _questId);
-        }
     }
 
     function getOwnedTokenIdsOfQuest(

--- a/test/Erc1155Quest.spec.ts
+++ b/test/Erc1155Quest.spec.ts
@@ -247,7 +247,7 @@ describe('Erc1155Quest', () => {
     })
 
     it('should only transfer the correct amount of rewards', async () => {
-      await deployedRabbitholeReceiptContract.mint(owner.address, 1, questId)
+      await deployedRabbitholeReceiptContract.mint(owner.address, questId)
       await deployedQuestContract.start()
 
       await ethers.provider.send('evm_increaseTime', [86400])
@@ -263,62 +263,11 @@ describe('Erc1155Quest', () => {
       await deployedQuestContract.claim()
       const endingBalance = await deployedSampleErc1155Contract.balanceOf(owner.address, rewardAmount)
       expect(endingBalance.toString()).to.equal('1')
-      await ethers.provider.send('evm_increaseTime', [-86400])
-    })
-
-    it('should let you claim mulitiple rewards if you have multiple tokens', async () => {
-      await deployedRabbitholeReceiptContract.mint(owner.address, 2, questId)
-      await deployedQuestContract.start()
-
-      await ethers.provider.send('evm_increaseTime', [86400])
-
-      const startingBalance = await deployedSampleErc1155Contract.balanceOf(owner.address, rewardAmount)
-      expect(startingBalance.toString()).to.equal('0')
-
-      const totalTokens = await deployedRabbitholeReceiptContract.getOwnedTokenIdsOfQuest(questId, owner.address)
-      expect(totalTokens.length).to.equal(2)
-
-      expect(await deployedQuestContract.isClaimed(1)).to.equal(false)
-
-      await deployedQuestContract.claim()
-      const endingBalance = await deployedSampleErc1155Contract.balanceOf(owner.address, rewardAmount)
-      expect(endingBalance.toString()).to.equal('2')
-      await ethers.provider.send('evm_increaseTime', [-86400])
-    })
-
-    it('should let multiple claim if you have already claimed', async () => {
-      await deployedRabbitholeReceiptContract.mint(owner.address, 3, questId)
-      await deployedRabbitholeReceiptContract.transferFrom(owner.address, firstAddress.address, 2)
-      await deployedRabbitholeReceiptContract.transferFrom(owner.address, secondAddress.address, 3)
-      await deployedQuestContract.start()
-
-      await ethers.provider.send('evm_increaseTime', [86400])
-
-      const startingBalance = await deployedSampleErc1155Contract.balanceOf(owner.address, rewardAmount)
-      expect(startingBalance.toString()).to.equal('0')
-
-      const totalTokens = await deployedRabbitholeReceiptContract.getOwnedTokenIdsOfQuest(questId, owner.address)
-      expect(totalTokens.length).to.equal(1)
-
-      expect(await deployedQuestContract.isClaimed(1)).to.equal(false)
-
-      await deployedQuestContract.claim()
-      const endingBalance = await deployedSampleErc1155Contract.balanceOf(owner.address, rewardAmount)
-      expect(endingBalance.toString()).to.equal('1')
-
-      await deployedQuestContract.connect(firstAddress).claim()
-      const secondEndingBalance = await deployedSampleErc1155Contract.balanceOf(firstAddress.address, rewardAmount)
-      expect(secondEndingBalance.toString()).to.equal('1')
-
-      await deployedQuestContract.connect(secondAddress).claim()
-      const thirdEndingBalance = await deployedSampleErc1155Contract.balanceOf(secondAddress.address, rewardAmount)
-      expect(thirdEndingBalance.toString()).to.equal('1')
-
       await ethers.provider.send('evm_increaseTime', [-86400])
     })
 
     it('should not let you claim if you have already claimed', async () => {
-      await deployedRabbitholeReceiptContract.mint(owner.address, 1, questId)
+      await deployedRabbitholeReceiptContract.mint(owner.address, questId)
       await deployedQuestContract.start()
 
       await ethers.provider.send('evm_increaseTime', [86400])

--- a/test/Erc1155Quest.spec.ts
+++ b/test/Erc1155Quest.spec.ts
@@ -234,7 +234,7 @@ describe('Erc1155Quest', () => {
       await deployedQuestContract.start()
       await ethers.provider.send('evm_increaseTime', [10000])
       await deployedQuestContract.withdrawRemainingTokens(owner.address)
-      await expect(deployedQuestContract.claim()).to.be.revertedWithCustomError(questContract, 'AmountExceedsBalance')
+      await expect(deployedQuestContract.claim()).to.be.revertedWithCustomError(questContract, 'NoTokensToClaim')
       await ethers.provider.send('evm_increaseTime', [-10000])
     })
 

--- a/test/Erc20Quest.spec.ts
+++ b/test/Erc20Quest.spec.ts
@@ -18,6 +18,7 @@ describe('Erc20Quest', async () => {
   let deployedSampleErc20Contract: SampleERC20
   let deployedRabbitholeReceiptContract: RabbitHoleReceipt
   let expiryDate: number, startDate: number
+  const mockAddress = '0x0000000000000000000000000000000000000000'
   const mnemonic = 'announce room limb pattern dry unit scale effort smooth jazz weasel alcohol'
   const questId = 'asdf'
   const allowList = 'ipfs://someCidToAnArrayOfAddresses'

--- a/test/Erc20Quest.spec.ts
+++ b/test/Erc20Quest.spec.ts
@@ -22,7 +22,7 @@ describe('Erc20Quest', async () => {
   const mnemonic = 'announce room limb pattern dry unit scale effort smooth jazz weasel alcohol'
   const questId = 'asdf'
   const allowList = 'ipfs://someCidToAnArrayOfAddresses'
-  const totalParticipants = 1000
+  const totalParticipants = 300
   const totalRewardsPlusFee = 120000
   const rewardAmount = 1000
   const questFee = 2000
@@ -128,256 +128,256 @@ describe('Erc20Quest', async () => {
     await deployedSampleErc20Contract.functions.transfer(distributorContractAddress, totalRewardsPlusFee * 100)
   }
 
-  // describe('Deployment', () => {
-  //   describe('when start time is in past', () => {
-  //     it('Should revert', async () => {
-  //       expect(
-  //         upgrades.deployProxy(questContract, [mockAddress, expiryDate, startDate - 1000, totalParticipants])
-  //       ).to.be.revertedWithCustomError(questContract, 'StartTimeInPast')
-  //     })
-  //   })
+  describe('Deployment', () => {
+    describe('when start time is in past', () => {
+      it('Should revert', async () => {
+        expect(
+          upgrades.deployProxy(questContract, [mockAddress, expiryDate, startDate - 1000, totalParticipants])
+        ).to.be.revertedWithCustomError(questContract, 'StartTimeInPast')
+      })
+    })
 
-  //   describe('when end time is in past', () => {
-  //     it('Should revert', async () => {
-  //       expect(
-  //         upgrades.deployProxy(questContract, [mockAddress, startDate - 1000, startDate, totalParticipants])
-  //       ).to.be.revertedWithCustomError(questContract, 'EndTimeInPast')
-  //     })
-  //   })
+    describe('when end time is in past', () => {
+      it('Should revert', async () => {
+        expect(
+          upgrades.deployProxy(questContract, [mockAddress, startDate - 1000, startDate, totalParticipants])
+        ).to.be.revertedWithCustomError(questContract, 'EndTimeInPast')
+      })
+    })
 
-  //   describe('setting public variables', () => {
-  //     it('Should set the token address with correct value', async () => {
-  //       const rewardContractAddress = await deployedQuestContract.rewardToken()
-  //       expect(rewardContractAddress).to.equal(deployedSampleErc20Contract.address)
-  //     })
+    describe('setting public variables', () => {
+      it('Should set the token address with correct value', async () => {
+        const rewardContractAddress = await deployedQuestContract.rewardToken()
+        expect(rewardContractAddress).to.equal(deployedSampleErc20Contract.address)
+      })
 
-  //     it('Should set the total participants with correct value', async () => {
-  //       const totalParticipants = await deployedQuestContract.totalParticipants()
-  //       expect(totalParticipants).to.equal(totalParticipants)
-  //     })
+      it('Should set the total participants with correct value', async () => {
+        const totalParticipants = await deployedQuestContract.totalParticipants()
+        expect(totalParticipants).to.equal(totalParticipants)
+      })
 
-  //     it('Should set has started with correct value', async () => {
-  //       const hasStarted = await deployedQuestContract.hasStarted()
-  //       expect(hasStarted).to.equal(false)
-  //     })
+      it('Should set has started with correct value', async () => {
+        const hasStarted = await deployedQuestContract.hasStarted()
+        expect(hasStarted).to.equal(false)
+      })
 
-  //     it('Should set the end time with correct value', async () => {
-  //       const endTime = await deployedQuestContract.endTime()
-  //       expect(endTime).to.equal(expiryDate)
-  //     })
+      it('Should set the end time with correct value', async () => {
+        const endTime = await deployedQuestContract.endTime()
+        expect(endTime).to.equal(expiryDate)
+      })
 
-  //     it('Should set the start time with correct value', async () => {
-  //       const startTime = await deployedQuestContract.startTime()
-  //       expect(startTime).to.equal(startDate)
-  //     })
+      it('Should set the start time with correct value', async () => {
+        const startTime = await deployedQuestContract.startTime()
+        expect(startTime).to.equal(startDate)
+      })
 
-  //     it('Should set the allowList with correct value', async () => {
-  //       const currentAllowList = await deployedQuestContract.allowList()
-  //       expect(currentAllowList).to.equal(allowList)
-  //     })
-  //   })
+      it('Should set the allowList with correct value', async () => {
+        const currentAllowList = await deployedQuestContract.allowList()
+        expect(currentAllowList).to.equal(allowList)
+      })
+    })
 
-  //   it('Deployment should set the correct owner address', async () => {
-  //     expect(await deployedQuestContract.owner()).to.equal(owner.address)
-  //   })
-  // })
+    it('Deployment should set the correct owner address', async () => {
+      expect(await deployedQuestContract.owner()).to.equal(owner.address)
+    })
+  })
 
-  // describe('start()', () => {
-  //   it('should only allow the owner to start', async () => {
-  //     await expect(deployedQuestContract.connect(firstAddress).start()).to.be.revertedWith(
-  //       'Ownable: caller is not the owner'
-  //     )
-  //   })
+  describe('start()', () => {
+    it('should only allow the owner to start', async () => {
+      await expect(deployedQuestContract.connect(firstAddress).start()).to.be.revertedWith(
+        'Ownable: caller is not the owner'
+      )
+    })
 
-  //   it('should set start correctly', async () => {
-  //     expect(await deployedQuestContract.hasStarted()).to.equal(false)
-  //     await deployedQuestContract.connect(owner).start()
-  //     expect(await deployedQuestContract.hasStarted()).to.equal(true)
-  //   })
-  // })
+    it('should set start correctly', async () => {
+      expect(await deployedQuestContract.hasStarted()).to.equal(false)
+      await deployedQuestContract.connect(owner).start()
+      expect(await deployedQuestContract.hasStarted()).to.equal(true)
+    })
+  })
 
-  // describe('pause()', () => {
-  //   it('should only allow the owner to pause', async () => {
-  //     await expect(deployedQuestContract.connect(firstAddress).pause()).to.be.revertedWith(
-  //       'Ownable: caller is not the owner'
-  //     )
-  //   })
+  describe('pause()', () => {
+    it('should only allow the owner to pause', async () => {
+      await expect(deployedQuestContract.connect(firstAddress).pause()).to.be.revertedWith(
+        'Ownable: caller is not the owner'
+      )
+    })
 
-  //   it('should set pause correctly', async () => {
-  //     expect(await deployedQuestContract.hasStarted()).to.equal(false)
-  //     await deployedQuestContract.connect(owner).start()
-  //     expect(await deployedQuestContract.isPaused()).to.equal(false)
-  //     await deployedQuestContract.connect(owner).pause()
-  //     expect(await deployedQuestContract.isPaused()).to.equal(true)
-  //   })
-  // })
+    it('should set pause correctly', async () => {
+      expect(await deployedQuestContract.hasStarted()).to.equal(false)
+      await deployedQuestContract.connect(owner).start()
+      expect(await deployedQuestContract.isPaused()).to.equal(false)
+      await deployedQuestContract.connect(owner).pause()
+      expect(await deployedQuestContract.isPaused()).to.equal(true)
+    })
+  })
 
-  // describe('unPause()', () => {
-  //   it('should only allow the owner to pause', async () => {
-  //     await expect(deployedQuestContract.connect(firstAddress).unPause()).to.be.revertedWith(
-  //       'Ownable: caller is not the owner'
-  //     )
-  //   })
+  describe('unPause()', () => {
+    it('should only allow the owner to pause', async () => {
+      await expect(deployedQuestContract.connect(firstAddress).unPause()).to.be.revertedWith(
+        'Ownable: caller is not the owner'
+      )
+    })
 
-  //   it('should set unPause correctly', async () => {
-  //     expect(await deployedQuestContract.hasStarted()).to.equal(false)
-  //     expect(await deployedQuestContract.isPaused()).to.equal(false)
-  //     await deployedQuestContract.connect(owner).start()
-  //     expect(await deployedQuestContract.isPaused()).to.equal(false)
-  //     await deployedQuestContract.connect(owner).pause()
-  //     expect(await deployedQuestContract.isPaused()).to.equal(true)
-  //     await deployedQuestContract.connect(owner).unPause()
-  //     expect(await deployedQuestContract.isPaused()).to.equal(false)
-  //   })
-  // })
+    it('should set unPause correctly', async () => {
+      expect(await deployedQuestContract.hasStarted()).to.equal(false)
+      expect(await deployedQuestContract.isPaused()).to.equal(false)
+      await deployedQuestContract.connect(owner).start()
+      expect(await deployedQuestContract.isPaused()).to.equal(false)
+      await deployedQuestContract.connect(owner).pause()
+      expect(await deployedQuestContract.isPaused()).to.equal(true)
+      await deployedQuestContract.connect(owner).unPause()
+      expect(await deployedQuestContract.isPaused()).to.equal(false)
+    })
+  })
 
-  // describe('setAllowList()', () => {
-  //   it('should set start correctly', async () => {
-  //     expect(await deployedQuestContract.allowList()).to.equal(allowList)
-  //     await deployedQuestContract.connect(owner).setAllowList('ipfs://someOtherCid')
-  //     expect(await deployedQuestContract.allowList()).to.equal('ipfs://someOtherCid')
-  //   })
+  describe('setAllowList()', () => {
+    it('should set start correctly', async () => {
+      expect(await deployedQuestContract.allowList()).to.equal(allowList)
+      await deployedQuestContract.connect(owner).setAllowList('ipfs://someOtherCid')
+      expect(await deployedQuestContract.allowList()).to.equal('ipfs://someOtherCid')
+    })
 
-  //   it('should only allow the owner to start', async () => {
-  //     await expect(deployedQuestContract.connect(firstAddress).setAllowList('ipfs://someOtherCid')).to.be.revertedWith(
-  //       'Ownable: caller is not the owner'
-  //     )
-  //   })
-  // })
+    it('should only allow the owner to start', async () => {
+      await expect(deployedQuestContract.connect(firstAddress).setAllowList('ipfs://someOtherCid')).to.be.revertedWith(
+        'Ownable: caller is not the owner'
+      )
+    })
+  })
 
-  // describe('claim()', async () => {
-  //   it('should fail if quest has not started yet', async () => {
-  //     expect(await deployedQuestContract.hasStarted()).to.equal(false)
-  //     await expect(deployedQuestContract.claim()).to.be.revertedWithCustomError(questContract, 'NotStarted')
-  //   })
+  describe('claim()', async () => {
+    it('should fail if quest has not started yet', async () => {
+      expect(await deployedQuestContract.hasStarted()).to.equal(false)
+      await expect(deployedQuestContract.claim()).to.be.revertedWithCustomError(questContract, 'NotStarted')
+    })
 
-  //   it('should fail if quest is paused', async () => {
-  //     await deployedQuestContract.start()
-  //     await ethers.provider.send('evm_increaseTime', [10000])
-  //     await deployedQuestContract.pause()
+    it('should fail if quest is paused', async () => {
+      await deployedQuestContract.start()
+      await ethers.provider.send('evm_increaseTime', [10000])
+      await deployedQuestContract.pause()
 
-  //     await expect(deployedQuestContract.claim()).to.be.revertedWithCustomError(questContract, 'QuestPaused')
-  //     await ethers.provider.send('evm_increaseTime', [-10000])
-  //   })
+      await expect(deployedQuestContract.claim()).to.be.revertedWithCustomError(questContract, 'QuestPaused')
+      await ethers.provider.send('evm_increaseTime', [-10000])
+    })
 
-  //   it('should fail if before start time stamp', async () => {
-  //     await deployedQuestContract.start()
-  //     await expect(deployedQuestContract.claim()).to.be.revertedWithCustomError(questContract, 'ClaimWindowNotStarted')
-  //   })
+    it('should fail if before start time stamp', async () => {
+      await deployedQuestContract.start()
+      await expect(deployedQuestContract.claim()).to.be.revertedWithCustomError(questContract, 'ClaimWindowNotStarted')
+    })
 
-  //   it('should fail if the contract is out of rewards', async () => {
-  //     await deployedQuestContract.start()
-  //     await ethers.provider.send('evm_increaseTime', [100000])
-  //     await deployedQuestContract.withdrawRemainingTokens(owner.address)
-  //     await expect(deployedQuestContract.claim()).to.be.revertedWithCustomError(questContract, 'NoTokensToClaim')
-  //     await ethers.provider.send('evm_increaseTime', [-100000])
-  //   })
+    it('should fail if the contract is out of rewards', async () => {
+      await deployedQuestContract.start()
+      await ethers.provider.send('evm_increaseTime', [100000])
+      await deployedQuestContract.withdrawRemainingTokens(owner.address)
+      await expect(deployedQuestContract.claim()).to.be.revertedWithCustomError(questContract, 'NoTokensToClaim')
+      await ethers.provider.send('evm_increaseTime', [-100000])
+    })
 
-  //   it('should only transfer the correct amount of rewards', async () => {
-  //     await deployedRabbitholeReceiptContract.mint(owner.address, 1, questId)
-  //     await deployedQuestContract.start()
+    it('should only transfer the correct amount of rewards', async () => {
+      await deployedRabbitholeReceiptContract.mint(owner.address, 1, questId)
+      await deployedQuestContract.start()
 
-  //     await ethers.provider.send('evm_increaseTime', [86400])
+      await ethers.provider.send('evm_increaseTime', [86400])
 
-  //     expect(await deployedSampleErc20Contract.balanceOf(owner.address)).to.equal(0)
+      expect(await deployedSampleErc20Contract.balanceOf(owner.address)).to.equal(0)
 
-  //     const totalTokens = await deployedRabbitholeReceiptContract.getOwnedTokenIdsOfQuest(questId, owner.address)
-  //     expect(totalTokens.length).to.equal(1)
+      const totalTokens = await deployedRabbitholeReceiptContract.getOwnedTokenIdsOfQuest(questId, owner.address)
+      expect(totalTokens.length).to.equal(1)
 
-  //     expect(await deployedQuestContract.isClaimed(1)).to.equal(false)
+      expect(await deployedQuestContract.isClaimed(1)).to.equal(false)
 
-  //     await deployedQuestContract.claim()
-  //     expect(await deployedSampleErc20Contract.balanceOf(owner.address)).to.equal(1000)
-  //     await ethers.provider.send('evm_increaseTime', [-86400])
-  //   })
+      await deployedQuestContract.claim()
+      expect(await deployedSampleErc20Contract.balanceOf(owner.address)).to.equal(1000)
+      await ethers.provider.send('evm_increaseTime', [-86400])
+    })
 
-  //   it('should let you claim mulitiple rewards if you have multiple tokens', async () => {
-  //     await deployedRabbitholeReceiptContract.mint(owner.address, 2, questId)
-  //     await deployedQuestContract.start()
+    it('should let you claim mulitiple rewards if you have multiple tokens', async () => {
+      await deployedRabbitholeReceiptContract.mint(owner.address, 2, questId)
+      await deployedQuestContract.start()
 
-  //     await ethers.provider.send('evm_increaseTime', [86400])
+      await ethers.provider.send('evm_increaseTime', [86400])
 
-  //     const startingBalance = await deployedSampleErc20Contract.balanceOf(owner.address)
-  //     expect(startingBalance).to.equal(0)
+      const startingBalance = await deployedSampleErc20Contract.balanceOf(owner.address)
+      expect(startingBalance).to.equal(0)
 
-  //     const totalTokens = await deployedRabbitholeReceiptContract.getOwnedTokenIdsOfQuest(questId, owner.address)
-  //     expect(totalTokens.length).to.equal(2)
+      const totalTokens = await deployedRabbitholeReceiptContract.getOwnedTokenIdsOfQuest(questId, owner.address)
+      expect(totalTokens.length).to.equal(2)
 
-  //     expect(await deployedQuestContract.isClaimed(1)).to.equal(false)
+      expect(await deployedQuestContract.isClaimed(1)).to.equal(false)
 
-  //     await deployedQuestContract.claim()
-  //     const endingBalance = await deployedSampleErc20Contract.balanceOf(owner.address)
-  //     expect(endingBalance).to.equal(2000)
-  //     await ethers.provider.send('evm_increaseTime', [-86400])
-  //   })
+      await deployedQuestContract.claim()
+      const endingBalance = await deployedSampleErc20Contract.balanceOf(owner.address)
+      expect(endingBalance).to.equal(2000)
+      await ethers.provider.send('evm_increaseTime', [-86400])
+    })
 
-  //   it('should let multiple claim if you have already claimed', async () => {
-  //     await deployedRabbitholeReceiptContract.mint(owner.address, 3, questId)
-  //     await deployedRabbitholeReceiptContract.transferFrom(owner.address, firstAddress.address, 2)
-  //     await deployedRabbitholeReceiptContract.transferFrom(owner.address, secondAddress.address, 3)
-  //     await deployedQuestContract.start()
+    it('should let multiple claim if you have already claimed', async () => {
+      await deployedRabbitholeReceiptContract.mint(owner.address, 3, questId)
+      await deployedRabbitholeReceiptContract.transferFrom(owner.address, firstAddress.address, 2)
+      await deployedRabbitholeReceiptContract.transferFrom(owner.address, secondAddress.address, 3)
+      await deployedQuestContract.start()
 
-  //     await ethers.provider.send('evm_increaseTime', [86400])
+      await ethers.provider.send('evm_increaseTime', [86400])
 
-  //     const startingBalance = await deployedSampleErc20Contract.balanceOf(owner.address)
-  //     expect(startingBalance).to.equal(0)
+      const startingBalance = await deployedSampleErc20Contract.balanceOf(owner.address)
+      expect(startingBalance).to.equal(0)
 
-  //     const totalTokens = await deployedRabbitholeReceiptContract.getOwnedTokenIdsOfQuest(questId, owner.address)
-  //     expect(totalTokens.length).to.equal(1)
+      const totalTokens = await deployedRabbitholeReceiptContract.getOwnedTokenIdsOfQuest(questId, owner.address)
+      expect(totalTokens.length).to.equal(1)
 
-  //     expect(await deployedQuestContract.isClaimed(1)).to.equal(false)
+      expect(await deployedQuestContract.isClaimed(1)).to.equal(false)
 
-  //     await deployedQuestContract.claim()
-  //     const endingBalance = await deployedSampleErc20Contract.balanceOf(owner.address)
-  //     expect(endingBalance).to.equal(1000)
+      await deployedQuestContract.claim()
+      const endingBalance = await deployedSampleErc20Contract.balanceOf(owner.address)
+      expect(endingBalance).to.equal(1000)
 
-  //     await deployedQuestContract.connect(firstAddress).claim()
-  //     const secondEndingBalance = await deployedSampleErc20Contract.balanceOf(firstAddress.address)
-  //     expect(secondEndingBalance).to.equal(1000)
+      await deployedQuestContract.connect(firstAddress).claim()
+      const secondEndingBalance = await deployedSampleErc20Contract.balanceOf(firstAddress.address)
+      expect(secondEndingBalance).to.equal(1000)
 
-  //     await deployedQuestContract.connect(secondAddress).claim()
-  //     const thirdEndingBalance = await deployedSampleErc20Contract.balanceOf(secondAddress.address)
-  //     expect(thirdEndingBalance).to.equal(1000)
+      await deployedQuestContract.connect(secondAddress).claim()
+      const thirdEndingBalance = await deployedSampleErc20Contract.balanceOf(secondAddress.address)
+      expect(thirdEndingBalance).to.equal(1000)
 
-  //     await ethers.provider.send('evm_increaseTime', [-86400])
-  //   })
+      await ethers.provider.send('evm_increaseTime', [-86400])
+    })
 
-  //   it('should not let you claim if you have already claimed', async () => {
-  //     await deployedRabbitholeReceiptContract.mint(owner.address, 1, questId)
-  //     await deployedQuestContract.start()
+    it('should not let you claim if you have already claimed', async () => {
+      await deployedRabbitholeReceiptContract.mint(owner.address, 1, questId)
+      await deployedQuestContract.start()
 
-  //     await ethers.provider.send('evm_increaseTime', [86400])
+      await ethers.provider.send('evm_increaseTime', [86400])
 
-  //     await deployedQuestContract.claim()
-  //     await expect(deployedQuestContract.claim()).to.be.revertedWithCustomError(questContract, 'AlreadyClaimed')
-  //     await ethers.provider.send('evm_increaseTime', [-86400])
-  //   })
-  // })
+      await deployedQuestContract.claim()
+      await expect(deployedQuestContract.claim()).to.be.revertedWithCustomError(questContract, 'AlreadyClaimed')
+      await ethers.provider.send('evm_increaseTime', [-86400])
+    })
+  })
 
   describe('withdrawRemainingTokens()', async () => {
-  //   it('should only allow the owner to withdrawRemainingTokens', async () => {
-  //     await expect(deployedQuestContract.connect(firstAddress).withdrawRemainingTokens(owner.address)).to.be.revertedWith(
-  //       'Ownable: caller is not the owner'
-  //     )
-  //   })
+    it('should only allow the owner to withdrawRemainingTokens', async () => {
+      await expect(deployedQuestContract.connect(firstAddress).withdrawRemainingTokens(owner.address)).to.be.revertedWith(
+        'Ownable: caller is not the owner'
+      )
+    })
 
-  //   it('should revert if trying to withdrawRemainingTokens before end date', async () => {
-  //     await expect(deployedQuestContract.connect(owner).withdrawRemainingTokens(owner.address)).to.be.revertedWithCustomError(
-  //       questContract,
-  //       'NoWithdrawDuringClaim'
-  //     )
-  //   })
+    it('should revert if trying to withdrawRemainingTokens before end date', async () => {
+      await expect(deployedQuestContract.connect(owner).withdrawRemainingTokens(owner.address)).to.be.revertedWithCustomError(
+        questContract,
+        'NoWithdrawDuringClaim'
+      )
+    })
 
-  //   it('if zero receiptRedeemers and reedemedTokens transfer all rewards back to owner', async () => {
-  //     expect(await deployedSampleErc20Contract.balanceOf(deployedQuestContract.address)).to.equal(totalRewardsPlusFee * 100)
-  //     expect(await deployedSampleErc20Contract.balanceOf(owner.address)).to.equal(0)
-  //     await ethers.provider.send('evm_increaseTime', [100001])
-  //     await deployedQuestContract.connect(owner).withdrawRemainingTokens(owner.address)
+    it('if zero receiptRedeemers and reedemedTokens transfer all rewards back to owner', async () => {
+      expect(await deployedSampleErc20Contract.balanceOf(deployedQuestContract.address)).to.equal(totalRewardsPlusFee * 100)
+      expect(await deployedSampleErc20Contract.balanceOf(owner.address)).to.equal(0)
+      await ethers.provider.send('evm_increaseTime', [100001])
+      await deployedQuestContract.connect(owner).withdrawRemainingTokens(owner.address)
 
-  //     expect(await deployedSampleErc20Contract.balanceOf(deployedQuestContract.address)).to.equal(0)
-  //     expect(await deployedSampleErc20Contract.balanceOf(owner.address)).to.equal(totalRewardsPlusFee * 100)
-  //     await ethers.provider.send('evm_increaseTime', [-100001])
-  // })
+      expect(await deployedSampleErc20Contract.balanceOf(deployedQuestContract.address)).to.equal(0)
+      expect(await deployedSampleErc20Contract.balanceOf(owner.address)).to.equal(totalRewardsPlusFee * 100)
+      await ethers.provider.send('evm_increaseTime', [-100001])
+  })
 
     it('should transfer non-claimable rewards back to owner', async () => {
       await deployedFactoryContract.connect(firstAddress).mintReceipt(1, questId, messageHash, signature)
@@ -389,8 +389,7 @@ describe('Erc20Quest', async () => {
       await deployedQuestContract.withdrawRemainingTokens(owner.address)
 
       expect(await deployedSampleErc20Contract.balanceOf(deployedQuestContract.address)).to.equal(200)
-
-      expect(await deployedSampleErc20Contract.balanceOf(owner.address)).to.equal((totalRewardsPlusFee * 100) - 1200)
+      expect(await deployedSampleErc20Contract.balanceOf(owner.address)).to.equal((totalRewardsPlusFee * 100) - (1 * 1000) - 200)
       await ethers.provider.send('evm_increaseTime', [-100001])
       await ethers.provider.send('evm_increaseTime', [-86400])
     })
@@ -400,20 +399,22 @@ describe('Erc20Quest', async () => {
     it('should transfer protocol fees back to owner', async () => {
       const beginningContractBalance = await deployedSampleErc20Contract.balanceOf(deployedQuestContract.address)
 
-      await deployedFactoryContract.connect(firstAddress).mintReceipt(100, questId, messageHash, signature)
+      await deployedFactoryContract.connect(firstAddress).mintReceipt(25, questId, messageHash, signature)
       await deployedQuestContract.start()
       await ethers.provider.send('evm_increaseTime', [86400])
       expect(await deployedSampleErc20Contract.balanceOf(protocolFeeAddress)).to.equal(0)
 
       await deployedQuestContract.connect(firstAddress).claim()
-      expect(await deployedSampleErc20Contract.balanceOf(firstAddress.address)).to.equal(100000)
+      expect(await deployedSampleErc20Contract.balanceOf(firstAddress.address)).to.equal(25 * 1000)
       expect(beginningContractBalance).to.equal(totalRewardsPlusFee * 100)
 
       await ethers.provider.send('evm_increaseTime', [100001])
       await deployedQuestContract.withdrawFee()
 
-      expect(await deployedSampleErc20Contract.balanceOf(deployedQuestContract.address)).to.equal((totalRewardsPlusFee * 100) - 100200)
-      expect(await deployedSampleErc20Contract.balanceOf(protocolFeeAddress)).to.equal(200) // (1000) * 20% fee
+      expect(await deployedSampleErc20Contract.balanceOf(deployedQuestContract.address)).to.equal((totalRewardsPlusFee * 100) - (25 * 1000) - 200)
+      expect(await deployedQuestContract.receiptRedeemers()).to.equal(1)
+      expect(await deployedQuestContract.protocolFee()).to.equal(200) // 1 * 1000 * (2000 / 10000) = 200
+      expect(await deployedSampleErc20Contract.balanceOf(protocolFeeAddress)).to.equal(200)
 
       await ethers.provider.send('evm_increaseTime', [-100001])
       await ethers.provider.send('evm_increaseTime', [-86400])

--- a/test/Erc20Quest.spec.ts
+++ b/test/Erc20Quest.spec.ts
@@ -23,8 +23,8 @@ describe('Erc20Quest', async () => {
   const questId = 'asdf'
   const allowList = 'ipfs://someCidToAnArrayOfAddresses'
   const totalParticipants = 1000
-  const totalRewardsPlusFee = 1200
-  const rewardAmount = 1
+  const totalRewardsPlusFee = 120000
+  const rewardAmount = 1000
   const questFee = 2000
   let owner: SignerWithAddress
   let firstAddress: SignerWithAddress
@@ -119,265 +119,265 @@ describe('Erc20Quest', async () => {
   }
 
   const deploySampleErc20Contract = async () => {
-    deployedSampleErc20Contract = await sampleERC20Contract.deploy('RewardToken', 'RTC', 1200, owner.address)
+    deployedSampleErc20Contract = await sampleERC20Contract.deploy('RewardToken', 'RTC', totalRewardsPlusFee * 100, owner.address)
     await deployedSampleErc20Contract.deployed()
   }
 
   const transferRewardsToDistributor = async () => {
     const distributorContractAddress = deployedQuestContract.address
-    await deployedSampleErc20Contract.functions.transfer(distributorContractAddress, 1200)
+    await deployedSampleErc20Contract.functions.transfer(distributorContractAddress, totalRewardsPlusFee * 100)
   }
 
-  describe('Deployment', () => {
-    describe('when start time is in past', () => {
-      it('Should revert', async () => {
-        expect(
-          upgrades.deployProxy(questContract, [mockAddress, expiryDate, startDate - 1000, totalParticipants])
-        ).to.be.revertedWithCustomError(questContract, 'StartTimeInPast')
-      })
-    })
+  // describe('Deployment', () => {
+  //   describe('when start time is in past', () => {
+  //     it('Should revert', async () => {
+  //       expect(
+  //         upgrades.deployProxy(questContract, [mockAddress, expiryDate, startDate - 1000, totalParticipants])
+  //       ).to.be.revertedWithCustomError(questContract, 'StartTimeInPast')
+  //     })
+  //   })
 
-    describe('when end time is in past', () => {
-      it('Should revert', async () => {
-        expect(
-          upgrades.deployProxy(questContract, [mockAddress, startDate - 1000, startDate, totalParticipants])
-        ).to.be.revertedWithCustomError(questContract, 'EndTimeInPast')
-      })
-    })
+  //   describe('when end time is in past', () => {
+  //     it('Should revert', async () => {
+  //       expect(
+  //         upgrades.deployProxy(questContract, [mockAddress, startDate - 1000, startDate, totalParticipants])
+  //       ).to.be.revertedWithCustomError(questContract, 'EndTimeInPast')
+  //     })
+  //   })
 
-    describe('setting public variables', () => {
-      it('Should set the token address with correct value', async () => {
-        const rewardContractAddress = await deployedQuestContract.rewardToken()
-        expect(rewardContractAddress).to.equal(deployedSampleErc20Contract.address)
-      })
+  //   describe('setting public variables', () => {
+  //     it('Should set the token address with correct value', async () => {
+  //       const rewardContractAddress = await deployedQuestContract.rewardToken()
+  //       expect(rewardContractAddress).to.equal(deployedSampleErc20Contract.address)
+  //     })
 
-      it('Should set the total participants with correct value', async () => {
-        const totalParticipants = await deployedQuestContract.totalParticipants()
-        expect(totalParticipants).to.equal(totalParticipants)
-      })
+  //     it('Should set the total participants with correct value', async () => {
+  //       const totalParticipants = await deployedQuestContract.totalParticipants()
+  //       expect(totalParticipants).to.equal(totalParticipants)
+  //     })
 
-      it('Should set has started with correct value', async () => {
-        const hasStarted = await deployedQuestContract.hasStarted()
-        expect(hasStarted).to.equal(false)
-      })
+  //     it('Should set has started with correct value', async () => {
+  //       const hasStarted = await deployedQuestContract.hasStarted()
+  //       expect(hasStarted).to.equal(false)
+  //     })
 
-      it('Should set the end time with correct value', async () => {
-        const endTime = await deployedQuestContract.endTime()
-        expect(endTime).to.equal(expiryDate)
-      })
+  //     it('Should set the end time with correct value', async () => {
+  //       const endTime = await deployedQuestContract.endTime()
+  //       expect(endTime).to.equal(expiryDate)
+  //     })
 
-      it('Should set the start time with correct value', async () => {
-        const startTime = await deployedQuestContract.startTime()
-        expect(startTime).to.equal(startDate)
-      })
+  //     it('Should set the start time with correct value', async () => {
+  //       const startTime = await deployedQuestContract.startTime()
+  //       expect(startTime).to.equal(startDate)
+  //     })
 
-      it('Should set the allowList with correct value', async () => {
-        const currentAllowList = await deployedQuestContract.allowList()
-        expect(currentAllowList).to.equal(allowList)
-      })
-    })
+  //     it('Should set the allowList with correct value', async () => {
+  //       const currentAllowList = await deployedQuestContract.allowList()
+  //       expect(currentAllowList).to.equal(allowList)
+  //     })
+  //   })
 
-    it('Deployment should set the correct owner address', async () => {
-      expect(await deployedQuestContract.owner()).to.equal(owner.address)
-    })
-  })
+  //   it('Deployment should set the correct owner address', async () => {
+  //     expect(await deployedQuestContract.owner()).to.equal(owner.address)
+  //   })
+  // })
 
-  describe('start()', () => {
-    it('should only allow the owner to start', async () => {
-      await expect(deployedQuestContract.connect(firstAddress).start()).to.be.revertedWith(
-        'Ownable: caller is not the owner'
-      )
-    })
+  // describe('start()', () => {
+  //   it('should only allow the owner to start', async () => {
+  //     await expect(deployedQuestContract.connect(firstAddress).start()).to.be.revertedWith(
+  //       'Ownable: caller is not the owner'
+  //     )
+  //   })
 
-    it('should set start correctly', async () => {
-      expect(await deployedQuestContract.hasStarted()).to.equal(false)
-      await deployedQuestContract.connect(owner).start()
-      expect(await deployedQuestContract.hasStarted()).to.equal(true)
-    })
-  })
+  //   it('should set start correctly', async () => {
+  //     expect(await deployedQuestContract.hasStarted()).to.equal(false)
+  //     await deployedQuestContract.connect(owner).start()
+  //     expect(await deployedQuestContract.hasStarted()).to.equal(true)
+  //   })
+  // })
 
-  describe('pause()', () => {
-    it('should only allow the owner to pause', async () => {
-      await expect(deployedQuestContract.connect(firstAddress).pause()).to.be.revertedWith(
-        'Ownable: caller is not the owner'
-      )
-    })
+  // describe('pause()', () => {
+  //   it('should only allow the owner to pause', async () => {
+  //     await expect(deployedQuestContract.connect(firstAddress).pause()).to.be.revertedWith(
+  //       'Ownable: caller is not the owner'
+  //     )
+  //   })
 
-    it('should set pause correctly', async () => {
-      expect(await deployedQuestContract.hasStarted()).to.equal(false)
-      await deployedQuestContract.connect(owner).start()
-      expect(await deployedQuestContract.isPaused()).to.equal(false)
-      await deployedQuestContract.connect(owner).pause()
-      expect(await deployedQuestContract.isPaused()).to.equal(true)
-    })
-  })
+  //   it('should set pause correctly', async () => {
+  //     expect(await deployedQuestContract.hasStarted()).to.equal(false)
+  //     await deployedQuestContract.connect(owner).start()
+  //     expect(await deployedQuestContract.isPaused()).to.equal(false)
+  //     await deployedQuestContract.connect(owner).pause()
+  //     expect(await deployedQuestContract.isPaused()).to.equal(true)
+  //   })
+  // })
 
-  describe('unPause()', () => {
-    it('should only allow the owner to pause', async () => {
-      await expect(deployedQuestContract.connect(firstAddress).unPause()).to.be.revertedWith(
-        'Ownable: caller is not the owner'
-      )
-    })
+  // describe('unPause()', () => {
+  //   it('should only allow the owner to pause', async () => {
+  //     await expect(deployedQuestContract.connect(firstAddress).unPause()).to.be.revertedWith(
+  //       'Ownable: caller is not the owner'
+  //     )
+  //   })
 
-    it('should set unPause correctly', async () => {
-      expect(await deployedQuestContract.hasStarted()).to.equal(false)
-      expect(await deployedQuestContract.isPaused()).to.equal(false)
-      await deployedQuestContract.connect(owner).start()
-      expect(await deployedQuestContract.isPaused()).to.equal(false)
-      await deployedQuestContract.connect(owner).pause()
-      expect(await deployedQuestContract.isPaused()).to.equal(true)
-      await deployedQuestContract.connect(owner).unPause()
-      expect(await deployedQuestContract.isPaused()).to.equal(false)
-    })
-  })
+  //   it('should set unPause correctly', async () => {
+  //     expect(await deployedQuestContract.hasStarted()).to.equal(false)
+  //     expect(await deployedQuestContract.isPaused()).to.equal(false)
+  //     await deployedQuestContract.connect(owner).start()
+  //     expect(await deployedQuestContract.isPaused()).to.equal(false)
+  //     await deployedQuestContract.connect(owner).pause()
+  //     expect(await deployedQuestContract.isPaused()).to.equal(true)
+  //     await deployedQuestContract.connect(owner).unPause()
+  //     expect(await deployedQuestContract.isPaused()).to.equal(false)
+  //   })
+  // })
 
-  describe('setAllowList()', () => {
-    it('should set start correctly', async () => {
-      expect(await deployedQuestContract.allowList()).to.equal(allowList)
-      await deployedQuestContract.connect(owner).setAllowList('ipfs://someOtherCid')
-      expect(await deployedQuestContract.allowList()).to.equal('ipfs://someOtherCid')
-    })
+  // describe('setAllowList()', () => {
+  //   it('should set start correctly', async () => {
+  //     expect(await deployedQuestContract.allowList()).to.equal(allowList)
+  //     await deployedQuestContract.connect(owner).setAllowList('ipfs://someOtherCid')
+  //     expect(await deployedQuestContract.allowList()).to.equal('ipfs://someOtherCid')
+  //   })
 
-    it('should only allow the owner to start', async () => {
-      await expect(deployedQuestContract.connect(firstAddress).setAllowList('ipfs://someOtherCid')).to.be.revertedWith(
-        'Ownable: caller is not the owner'
-      )
-    })
-  })
+  //   it('should only allow the owner to start', async () => {
+  //     await expect(deployedQuestContract.connect(firstAddress).setAllowList('ipfs://someOtherCid')).to.be.revertedWith(
+  //       'Ownable: caller is not the owner'
+  //     )
+  //   })
+  // })
 
-  describe('claim()', async () => {
-    it('should fail if quest has not started yet', async () => {
-      expect(await deployedQuestContract.hasStarted()).to.equal(false)
-      await expect(deployedQuestContract.claim()).to.be.revertedWithCustomError(questContract, 'NotStarted')
-    })
+  // describe('claim()', async () => {
+  //   it('should fail if quest has not started yet', async () => {
+  //     expect(await deployedQuestContract.hasStarted()).to.equal(false)
+  //     await expect(deployedQuestContract.claim()).to.be.revertedWithCustomError(questContract, 'NotStarted')
+  //   })
 
-    it('should fail if quest is paused', async () => {
-      await deployedQuestContract.start()
-      await ethers.provider.send('evm_increaseTime', [10000])
-      await deployedQuestContract.pause()
+  //   it('should fail if quest is paused', async () => {
+  //     await deployedQuestContract.start()
+  //     await ethers.provider.send('evm_increaseTime', [10000])
+  //     await deployedQuestContract.pause()
 
-      await expect(deployedQuestContract.claim()).to.be.revertedWithCustomError(questContract, 'QuestPaused')
-      await ethers.provider.send('evm_increaseTime', [-10000])
-    })
+  //     await expect(deployedQuestContract.claim()).to.be.revertedWithCustomError(questContract, 'QuestPaused')
+  //     await ethers.provider.send('evm_increaseTime', [-10000])
+  //   })
 
-    it('should fail if before start time stamp', async () => {
-      await deployedQuestContract.start()
-      await expect(deployedQuestContract.claim()).to.be.revertedWithCustomError(questContract, 'ClaimWindowNotStarted')
-    })
+  //   it('should fail if before start time stamp', async () => {
+  //     await deployedQuestContract.start()
+  //     await expect(deployedQuestContract.claim()).to.be.revertedWithCustomError(questContract, 'ClaimWindowNotStarted')
+  //   })
 
-    it('should fail if the contract is out of rewards', async () => {
-      await deployedQuestContract.start()
-      await ethers.provider.send('evm_increaseTime', [100000])
-      await deployedQuestContract.withdrawRemainingTokens(owner.address)
-      await expect(deployedQuestContract.claim()).to.be.revertedWithCustomError(questContract, 'NoTokensToClaim')
-      await ethers.provider.send('evm_increaseTime', [-100000])
-    })
+  //   it('should fail if the contract is out of rewards', async () => {
+  //     await deployedQuestContract.start()
+  //     await ethers.provider.send('evm_increaseTime', [100000])
+  //     await deployedQuestContract.withdrawRemainingTokens(owner.address)
+  //     await expect(deployedQuestContract.claim()).to.be.revertedWithCustomError(questContract, 'NoTokensToClaim')
+  //     await ethers.provider.send('evm_increaseTime', [-100000])
+  //   })
 
-    it('should only transfer the correct amount of rewards', async () => {
-      await deployedRabbitholeReceiptContract.mint(owner.address, 1, questId)
-      await deployedQuestContract.start()
+  //   it('should only transfer the correct amount of rewards', async () => {
+  //     await deployedRabbitholeReceiptContract.mint(owner.address, 1, questId)
+  //     await deployedQuestContract.start()
 
-      await ethers.provider.send('evm_increaseTime', [86400])
+  //     await ethers.provider.send('evm_increaseTime', [86400])
 
-      expect(await deployedSampleErc20Contract.balanceOf(owner.address)).to.equal(0)
+  //     expect(await deployedSampleErc20Contract.balanceOf(owner.address)).to.equal(0)
 
-      const totalTokens = await deployedRabbitholeReceiptContract.getOwnedTokenIdsOfQuest(questId, owner.address)
-      expect(totalTokens.length).to.equal(1)
+  //     const totalTokens = await deployedRabbitholeReceiptContract.getOwnedTokenIdsOfQuest(questId, owner.address)
+  //     expect(totalTokens.length).to.equal(1)
 
-      expect(await deployedQuestContract.isClaimed(1)).to.equal(false)
+  //     expect(await deployedQuestContract.isClaimed(1)).to.equal(false)
 
-      await deployedQuestContract.claim()
-      expect(await deployedSampleErc20Contract.balanceOf(owner.address)).to.equal(1)
-      await ethers.provider.send('evm_increaseTime', [-86400])
-    })
+  //     await deployedQuestContract.claim()
+  //     expect(await deployedSampleErc20Contract.balanceOf(owner.address)).to.equal(1000)
+  //     await ethers.provider.send('evm_increaseTime', [-86400])
+  //   })
 
-    it('should let you claim mulitiple rewards if you have multiple tokens', async () => {
-      await deployedRabbitholeReceiptContract.mint(owner.address, 2, questId)
-      await deployedQuestContract.start()
+  //   it('should let you claim mulitiple rewards if you have multiple tokens', async () => {
+  //     await deployedRabbitholeReceiptContract.mint(owner.address, 2, questId)
+  //     await deployedQuestContract.start()
 
-      await ethers.provider.send('evm_increaseTime', [86400])
+  //     await ethers.provider.send('evm_increaseTime', [86400])
 
-      const startingBalance = await deployedSampleErc20Contract.balanceOf(owner.address)
-      expect(startingBalance).to.equal(0)
+  //     const startingBalance = await deployedSampleErc20Contract.balanceOf(owner.address)
+  //     expect(startingBalance).to.equal(0)
 
-      const totalTokens = await deployedRabbitholeReceiptContract.getOwnedTokenIdsOfQuest(questId, owner.address)
-      expect(totalTokens.length).to.equal(2)
+  //     const totalTokens = await deployedRabbitholeReceiptContract.getOwnedTokenIdsOfQuest(questId, owner.address)
+  //     expect(totalTokens.length).to.equal(2)
 
-      expect(await deployedQuestContract.isClaimed(1)).to.equal(false)
+  //     expect(await deployedQuestContract.isClaimed(1)).to.equal(false)
 
-      await deployedQuestContract.claim()
-      const endingBalance = await deployedSampleErc20Contract.balanceOf(owner.address)
-      expect(endingBalance).to.equal(2)
-      await ethers.provider.send('evm_increaseTime', [-86400])
-    })
+  //     await deployedQuestContract.claim()
+  //     const endingBalance = await deployedSampleErc20Contract.balanceOf(owner.address)
+  //     expect(endingBalance).to.equal(2000)
+  //     await ethers.provider.send('evm_increaseTime', [-86400])
+  //   })
 
-    it('should let multiple claim if you have already claimed', async () => {
-      await deployedRabbitholeReceiptContract.mint(owner.address, 3, questId)
-      await deployedRabbitholeReceiptContract.transferFrom(owner.address, firstAddress.address, 2)
-      await deployedRabbitholeReceiptContract.transferFrom(owner.address, secondAddress.address, 3)
-      await deployedQuestContract.start()
+  //   it('should let multiple claim if you have already claimed', async () => {
+  //     await deployedRabbitholeReceiptContract.mint(owner.address, 3, questId)
+  //     await deployedRabbitholeReceiptContract.transferFrom(owner.address, firstAddress.address, 2)
+  //     await deployedRabbitholeReceiptContract.transferFrom(owner.address, secondAddress.address, 3)
+  //     await deployedQuestContract.start()
 
-      await ethers.provider.send('evm_increaseTime', [86400])
+  //     await ethers.provider.send('evm_increaseTime', [86400])
 
-      const startingBalance = await deployedSampleErc20Contract.balanceOf(owner.address)
-      expect(startingBalance).to.equal(0)
+  //     const startingBalance = await deployedSampleErc20Contract.balanceOf(owner.address)
+  //     expect(startingBalance).to.equal(0)
 
-      const totalTokens = await deployedRabbitholeReceiptContract.getOwnedTokenIdsOfQuest(questId, owner.address)
-      expect(totalTokens.length).to.equal(1)
+  //     const totalTokens = await deployedRabbitholeReceiptContract.getOwnedTokenIdsOfQuest(questId, owner.address)
+  //     expect(totalTokens.length).to.equal(1)
 
-      expect(await deployedQuestContract.isClaimed(1)).to.equal(false)
+  //     expect(await deployedQuestContract.isClaimed(1)).to.equal(false)
 
-      await deployedQuestContract.claim()
-      const endingBalance = await deployedSampleErc20Contract.balanceOf(owner.address)
-      expect(endingBalance).to.equal(1)
+  //     await deployedQuestContract.claim()
+  //     const endingBalance = await deployedSampleErc20Contract.balanceOf(owner.address)
+  //     expect(endingBalance).to.equal(1000)
 
-      await deployedQuestContract.connect(firstAddress).claim()
-      const secondEndingBalance = await deployedSampleErc20Contract.balanceOf(firstAddress.address)
-      expect(secondEndingBalance).to.equal(1)
+  //     await deployedQuestContract.connect(firstAddress).claim()
+  //     const secondEndingBalance = await deployedSampleErc20Contract.balanceOf(firstAddress.address)
+  //     expect(secondEndingBalance).to.equal(1000)
 
-      await deployedQuestContract.connect(secondAddress).claim()
-      const thirdEndingBalance = await deployedSampleErc20Contract.balanceOf(secondAddress.address)
-      expect(thirdEndingBalance).to.equal(1)
+  //     await deployedQuestContract.connect(secondAddress).claim()
+  //     const thirdEndingBalance = await deployedSampleErc20Contract.balanceOf(secondAddress.address)
+  //     expect(thirdEndingBalance).to.equal(1000)
 
-      await ethers.provider.send('evm_increaseTime', [-86400])
-    })
+  //     await ethers.provider.send('evm_increaseTime', [-86400])
+  //   })
 
-    it('should not let you claim if you have already claimed', async () => {
-      await deployedRabbitholeReceiptContract.mint(owner.address, 1, questId)
-      await deployedQuestContract.start()
+  //   it('should not let you claim if you have already claimed', async () => {
+  //     await deployedRabbitholeReceiptContract.mint(owner.address, 1, questId)
+  //     await deployedQuestContract.start()
 
-      await ethers.provider.send('evm_increaseTime', [86400])
+  //     await ethers.provider.send('evm_increaseTime', [86400])
 
-      await deployedQuestContract.claim()
-      await expect(deployedQuestContract.claim()).to.be.revertedWithCustomError(questContract, 'AlreadyClaimed')
-      await ethers.provider.send('evm_increaseTime', [-86400])
-    })
-  })
+  //     await deployedQuestContract.claim()
+  //     await expect(deployedQuestContract.claim()).to.be.revertedWithCustomError(questContract, 'AlreadyClaimed')
+  //     await ethers.provider.send('evm_increaseTime', [-86400])
+  //   })
+  // })
 
   describe('withdrawRemainingTokens()', async () => {
-    it('should only allow the owner to withdrawRemainingTokens', async () => {
-      await expect(deployedQuestContract.connect(firstAddress).withdrawRemainingTokens(owner.address)).to.be.revertedWith(
-        'Ownable: caller is not the owner'
-      )
-    })
+  //   it('should only allow the owner to withdrawRemainingTokens', async () => {
+  //     await expect(deployedQuestContract.connect(firstAddress).withdrawRemainingTokens(owner.address)).to.be.revertedWith(
+  //       'Ownable: caller is not the owner'
+  //     )
+  //   })
 
-    it('should revert if trying to withdrawRemainingTokens before end date', async () => {
-      await expect(deployedQuestContract.connect(owner).withdrawRemainingTokens(owner.address)).to.be.revertedWithCustomError(
-        questContract,
-        'NoWithdrawDuringClaim'
-      )
-    })
+  //   it('should revert if trying to withdrawRemainingTokens before end date', async () => {
+  //     await expect(deployedQuestContract.connect(owner).withdrawRemainingTokens(owner.address)).to.be.revertedWithCustomError(
+  //       questContract,
+  //       'NoWithdrawDuringClaim'
+  //     )
+  //   })
 
-    it('if zero receiptRedeemers and reedemedTokens transfer all rewards back to owner', async () => {
-      expect(await deployedSampleErc20Contract.balanceOf(deployedQuestContract.address)).to.equal(totalRewardsPlusFee)
-      expect(await deployedSampleErc20Contract.balanceOf(owner.address)).to.equal(0)
-      await ethers.provider.send('evm_increaseTime', [100001])
-      await deployedQuestContract.connect(owner).withdrawRemainingTokens(owner.address)
+  //   it('if zero receiptRedeemers and reedemedTokens transfer all rewards back to owner', async () => {
+  //     expect(await deployedSampleErc20Contract.balanceOf(deployedQuestContract.address)).to.equal(totalRewardsPlusFee * 100)
+  //     expect(await deployedSampleErc20Contract.balanceOf(owner.address)).to.equal(0)
+  //     await ethers.provider.send('evm_increaseTime', [100001])
+  //     await deployedQuestContract.connect(owner).withdrawRemainingTokens(owner.address)
 
-      expect(await deployedSampleErc20Contract.balanceOf(deployedQuestContract.address)).to.equal(0)
-      expect(await deployedSampleErc20Contract.balanceOf(owner.address)).to.equal(totalRewardsPlusFee)
-      await ethers.provider.send('evm_increaseTime', [-100001])
-  })
+  //     expect(await deployedSampleErc20Contract.balanceOf(deployedQuestContract.address)).to.equal(0)
+  //     expect(await deployedSampleErc20Contract.balanceOf(owner.address)).to.equal(totalRewardsPlusFee * 100)
+  //     await ethers.provider.send('evm_increaseTime', [-100001])
+  // })
 
     it('should transfer non-claimable rewards back to owner', async () => {
       await deployedFactoryContract.connect(firstAddress).mintReceipt(1, questId, messageHash, signature)
@@ -388,9 +388,9 @@ describe('Erc20Quest', async () => {
       await ethers.provider.send('evm_increaseTime', [100001])
       await deployedQuestContract.withdrawRemainingTokens(owner.address)
 
-      expect(await deployedSampleErc20Contract.balanceOf(deployedQuestContract.address)).to.equal(0)
-      // 1 is subtracted because the firstAddress claimed 1 token
-      expect(await deployedSampleErc20Contract.balanceOf(owner.address)).to.equal(totalRewardsPlusFee - 1)
+      expect(await deployedSampleErc20Contract.balanceOf(deployedQuestContract.address)).to.equal(200)
+
+      expect(await deployedSampleErc20Contract.balanceOf(owner.address)).to.equal((totalRewardsPlusFee * 100) - 1200)
       await ethers.provider.send('evm_increaseTime', [-100001])
       await ethers.provider.send('evm_increaseTime', [-86400])
     })
@@ -406,14 +406,14 @@ describe('Erc20Quest', async () => {
       expect(await deployedSampleErc20Contract.balanceOf(protocolFeeAddress)).to.equal(0)
 
       await deployedQuestContract.connect(firstAddress).claim()
-      expect(await deployedSampleErc20Contract.balanceOf(firstAddress.address)).to.equal(100)
-      expect(beginningContractBalance).to.equal(totalRewardsPlusFee)
+      expect(await deployedSampleErc20Contract.balanceOf(firstAddress.address)).to.equal(100000)
+      expect(beginningContractBalance).to.equal(totalRewardsPlusFee * 100)
 
       await ethers.provider.send('evm_increaseTime', [100001])
       await deployedQuestContract.withdrawFee()
 
-      expect(await deployedSampleErc20Contract.balanceOf(deployedQuestContract.address)).to.equal(1100)
-      expect(await deployedSampleErc20Contract.balanceOf(protocolFeeAddress)).to.equal(0) // I don't think this math is correct
+      expect(await deployedSampleErc20Contract.balanceOf(deployedQuestContract.address)).to.equal((totalRewardsPlusFee * 100) - 100200)
+      expect(await deployedSampleErc20Contract.balanceOf(protocolFeeAddress)).to.equal(200) // (1000) * 20% fee
 
       await ethers.provider.send('evm_increaseTime', [-100001])
       await ethers.provider.send('evm_increaseTime', [-86400])

--- a/test/Erc20Quest.spec.ts
+++ b/test/Erc20Quest.spec.ts
@@ -1,6 +1,7 @@
 import { expect } from 'chai'
 import { ethers, upgrades } from 'hardhat'
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers'
+import { Wallet, utils } from 'ethers'
 import {
   Erc20Quest__factory,
   RabbitHoleReceipt__factory,
@@ -17,12 +18,13 @@ describe('Erc20Quest', async () => {
   let deployedSampleErc20Contract: SampleERC20
   let deployedRabbitholeReceiptContract: RabbitHoleReceipt
   let expiryDate: number, startDate: number
-  const mockAddress = '0x0000000000000000000000000000000000000000'
+  const mnemonic = 'announce room limb pattern dry unit scale effort smooth jazz weasel alcohol'
   const questId = 'asdf'
   const allowList = 'ipfs://someCidToAnArrayOfAddresses'
-  const totalRewards = 1000
+  const totalParticipants = 1000
   const totalRewardsPlusFee = 1200
-  const rewardAmount = 10
+  const rewardAmount = 1
+  const questFee = 2000
   let owner: SignerWithAddress
   let firstAddress: SignerWithAddress
   let secondAddress: SignerWithAddress
@@ -34,6 +36,9 @@ describe('Erc20Quest', async () => {
   const protocolFeeAddress = '0xE8B17e572c1Eea45fCE267F30aE38862CF03BC84'
   let deployedFactoryContract: QuestFactory
   let questFactoryContract: QuestFactory__factory
+  let wallet: Wallet
+  let messageHash: string
+  let signature: string
 
   beforeEach(async () => {
     const [local_owner, local_firstAddress, local_secondAddress, local_thirdAddress, local_fourthAddress] =
@@ -42,6 +47,7 @@ describe('Erc20Quest', async () => {
     sampleERC20Contract = await ethers.getContractFactory('SampleERC20')
     rabbitholeReceiptContract = await ethers.getContractFactory('RabbitHoleReceipt')
     questFactoryContract = await ethers.getContractFactory('QuestFactory')
+    wallet = Wallet.fromMnemonic(mnemonic)
 
     owner = local_owner
     firstAddress = local_firstAddress
@@ -49,18 +55,33 @@ describe('Erc20Quest', async () => {
     thirdAddress = local_thirdAddress
     fourthAddress = local_fourthAddress
 
-    expiryDate = Math.floor(Date.now() / 1000) + 10000
+    expiryDate = Math.floor(Date.now() / 1000) + 100000
     startDate = Math.floor(Date.now() / 1000) + 1000
     await deployRabbitholeReceiptContract()
     await deploySampleErc20Contract()
     await deployFactoryContract()
     await deployQuestContract()
     await transferRewardsToDistributor()
+
+    messageHash = utils.solidityKeccak256(['address', 'string'], [firstAddress.address.toLowerCase(), questId])
+    signature = await wallet.signMessage(utils.arrayify(messageHash))
+    const tx = await deployedFactoryContract.createQuest(
+      deployedSampleErc20Contract.address,
+      expiryDate,
+      startDate,
+      totalParticipants,
+      allowList,
+      rewardAmount,
+      'erc20',
+      questId,
+      questFee
+    )
+    await tx.wait()
   })
 
   const deployFactoryContract = async () => {
     deployedFactoryContract = (await upgrades.deployProxy(questFactoryContract, [
-      owner.address,
+      wallet.address,
       deployedRabbitholeReceiptContract.address,
       protocolFeeAddress,
     ])) as QuestFactory
@@ -84,12 +105,12 @@ describe('Erc20Quest', async () => {
       deployedSampleErc20Contract.address,
       expiryDate,
       startDate,
-      totalRewards,
+      totalParticipants,
       allowList,
       rewardAmount,
       questId,
       deployedRabbitholeReceiptContract.address,
-      2000,
+      questFee,
       protocolFeeAddress,
       deployedFactoryContract.address
     )) as Erc20Quest
@@ -110,7 +131,7 @@ describe('Erc20Quest', async () => {
     describe('when start time is in past', () => {
       it('Should revert', async () => {
         expect(
-          upgrades.deployProxy(questContract, [mockAddress, expiryDate, startDate - 1000, totalRewards])
+          upgrades.deployProxy(questContract, [mockAddress, expiryDate, startDate - 1000, totalParticipants])
         ).to.be.revertedWithCustomError(questContract, 'StartTimeInPast')
       })
     })
@@ -118,7 +139,7 @@ describe('Erc20Quest', async () => {
     describe('when end time is in past', () => {
       it('Should revert', async () => {
         expect(
-          upgrades.deployProxy(questContract, [mockAddress, startDate - 1000, startDate, totalRewards])
+          upgrades.deployProxy(questContract, [mockAddress, startDate - 1000, startDate, totalParticipants])
         ).to.be.revertedWithCustomError(questContract, 'EndTimeInPast')
       })
     })
@@ -129,9 +150,9 @@ describe('Erc20Quest', async () => {
         expect(rewardContractAddress).to.equal(deployedSampleErc20Contract.address)
       })
 
-      it('Should set the total reward amount with correct value', async () => {
-        const totalAmount = await deployedQuestContract.totalAmount()
-        expect(totalAmount).to.equal(totalRewards)
+      it('Should set the total participants with correct value', async () => {
+        const totalParticipants = await deployedQuestContract.totalParticipants()
+        expect(totalParticipants).to.equal(totalParticipants)
       })
 
       it('Should set has started with correct value', async () => {
@@ -231,9 +252,11 @@ describe('Erc20Quest', async () => {
 
     it('should fail if quest is paused', async () => {
       await deployedQuestContract.start()
+      await ethers.provider.send('evm_increaseTime', [10000])
       await deployedQuestContract.pause()
 
       await expect(deployedQuestContract.claim()).to.be.revertedWithCustomError(questContract, 'QuestPaused')
+      await ethers.provider.send('evm_increaseTime', [-10000])
     })
 
     it('should fail if before start time stamp', async () => {
@@ -243,19 +266,10 @@ describe('Erc20Quest', async () => {
 
     it('should fail if the contract is out of rewards', async () => {
       await deployedQuestContract.start()
-      await ethers.provider.send('evm_increaseTime', [10000])
-      await deployedQuestContract.withdrawRemainingTokens()
+      await ethers.provider.send('evm_increaseTime', [100000])
+      await deployedQuestContract.withdrawRemainingTokens(owner.address)
       await expect(deployedQuestContract.claim()).to.be.revertedWithCustomError(questContract, 'NoTokensToClaim')
-      await ethers.provider.send('evm_increaseTime', [-10000])
-    })
-
-    it('should fail if there are no tokens to claim', async () => {
-      await deployedQuestContract.start()
-      await ethers.provider.send('evm_increaseTime', [1000])
-
-      //todo add in token qcheck of length 0
-      await expect(deployedQuestContract.claim()).to.be.revertedWithCustomError(questContract, 'NoTokensToClaim')
-      await ethers.provider.send('evm_increaseTime', [-1000])
+      await ethers.provider.send('evm_increaseTime', [-100000])
     })
 
     it('should only transfer the correct amount of rewards', async () => {
@@ -264,8 +278,7 @@ describe('Erc20Quest', async () => {
 
       await ethers.provider.send('evm_increaseTime', [86400])
 
-      const startingBalance = await deployedSampleErc20Contract.functions.balanceOf(owner.address)
-      expect(startingBalance.toString()).to.equal('0')
+      expect(await deployedSampleErc20Contract.balanceOf(owner.address)).to.equal(0)
 
       const totalTokens = await deployedRabbitholeReceiptContract.getOwnedTokenIdsOfQuest(questId, owner.address)
       expect(totalTokens.length).to.equal(1)
@@ -273,8 +286,7 @@ describe('Erc20Quest', async () => {
       expect(await deployedQuestContract.isClaimed(1)).to.equal(false)
 
       await deployedQuestContract.claim()
-      const endingBalance = await deployedSampleErc20Contract.functions.balanceOf(owner.address)
-      expect(endingBalance.toString()).to.equal('10')
+      expect(await deployedSampleErc20Contract.balanceOf(owner.address)).to.equal(1)
       await ethers.provider.send('evm_increaseTime', [-86400])
     })
 
@@ -285,7 +297,7 @@ describe('Erc20Quest', async () => {
       await ethers.provider.send('evm_increaseTime', [86400])
 
       const startingBalance = await deployedSampleErc20Contract.balanceOf(owner.address)
-      expect(startingBalance.toString()).to.equal('0')
+      expect(startingBalance).to.equal(0)
 
       const totalTokens = await deployedRabbitholeReceiptContract.getOwnedTokenIdsOfQuest(questId, owner.address)
       expect(totalTokens.length).to.equal(2)
@@ -294,7 +306,7 @@ describe('Erc20Quest', async () => {
 
       await deployedQuestContract.claim()
       const endingBalance = await deployedSampleErc20Contract.balanceOf(owner.address)
-      expect(endingBalance.toString()).to.equal('20')
+      expect(endingBalance).to.equal(2)
       await ethers.provider.send('evm_increaseTime', [-86400])
     })
 
@@ -307,7 +319,7 @@ describe('Erc20Quest', async () => {
       await ethers.provider.send('evm_increaseTime', [86400])
 
       const startingBalance = await deployedSampleErc20Contract.balanceOf(owner.address)
-      expect(startingBalance.toString()).to.equal('0')
+      expect(startingBalance).to.equal(0)
 
       const totalTokens = await deployedRabbitholeReceiptContract.getOwnedTokenIdsOfQuest(questId, owner.address)
       expect(totalTokens.length).to.equal(1)
@@ -316,15 +328,15 @@ describe('Erc20Quest', async () => {
 
       await deployedQuestContract.claim()
       const endingBalance = await deployedSampleErc20Contract.balanceOf(owner.address)
-      expect(endingBalance.toString()).to.equal('10')
+      expect(endingBalance).to.equal(1)
 
       await deployedQuestContract.connect(firstAddress).claim()
       const secondEndingBalance = await deployedSampleErc20Contract.balanceOf(firstAddress.address)
-      expect(secondEndingBalance.toString()).to.equal('10')
+      expect(secondEndingBalance).to.equal(1)
 
       await deployedQuestContract.connect(secondAddress).claim()
       const thirdEndingBalance = await deployedSampleErc20Contract.balanceOf(secondAddress.address)
-      expect(thirdEndingBalance.toString()).to.equal('10')
+      expect(thirdEndingBalance).to.equal(1)
 
       await ethers.provider.send('evm_increaseTime', [-86400])
     })
@@ -343,59 +355,67 @@ describe('Erc20Quest', async () => {
 
   describe('withdrawRemainingTokens()', async () => {
     it('should only allow the owner to withdrawRemainingTokens', async () => {
-      await expect(deployedQuestContract.connect(firstAddress).withdrawRemainingTokens()).to.be.revertedWith(
+      await expect(deployedQuestContract.connect(firstAddress).withdrawRemainingTokens(owner.address)).to.be.revertedWith(
         'Ownable: caller is not the owner'
       )
     })
 
     it('should revert if trying to withdrawRemainingTokens before end date', async () => {
-      await expect(deployedQuestContract.connect(owner).withdrawRemainingTokens()).to.be.revertedWithCustomError(
+      await expect(deployedQuestContract.connect(owner).withdrawRemainingTokens(owner.address)).to.be.revertedWithCustomError(
         questContract,
         'NoWithdrawDuringClaim'
       )
     })
 
+    it('if zero receiptRedeemers and reedemedTokens transfer all rewards back to owner', async () => {
+      expect(await deployedSampleErc20Contract.balanceOf(deployedQuestContract.address)).to.equal(totalRewardsPlusFee)
+      expect(await deployedSampleErc20Contract.balanceOf(owner.address)).to.equal(0)
+      await ethers.provider.send('evm_increaseTime', [100001])
+      await deployedQuestContract.connect(owner).withdrawRemainingTokens(owner.address)
+
+      expect(await deployedSampleErc20Contract.balanceOf(deployedQuestContract.address)).to.equal(0)
+      expect(await deployedSampleErc20Contract.balanceOf(owner.address)).to.equal(totalRewardsPlusFee)
+      await ethers.provider.send('evm_increaseTime', [-100001])
+  })
+
     it('should transfer non-claimable rewards back to owner', async () => {
-      // TODO clean up this test
-      // const beginningContractBalance = await deployedSampleErc20Contract.balanceOf(deployedQuestContract.address)
-      // const beginningOwnerBalance = await deployedSampleErc20Contract.balanceOf(owner.address)
-      // expect(beginningContractBalance.toString()).to.equal(totalRewardsPlusFee.toString())
-      // expect(beginningOwnerBalance.toString()).to.equal('0')
-      // await ethers.provider.send('evm_increaseTime', [10001])
-      // await deployedQuestContract.connect(owner).withdrawRemainingTokens()
-      //
-      // const endContactBalance = await deployedSampleErc20Contract.balanceOf(deployedQuestContract.address)
-      // expect(endContactBalance.toString()).to.equal('0')
-      // await ethers.provider.send('evm_increaseTime', [-10001])
+      await deployedFactoryContract.connect(firstAddress).mintReceipt(1, questId, messageHash, signature)
+      await deployedQuestContract.start()
+      await ethers.provider.send('evm_increaseTime', [86400])
+      await deployedQuestContract.connect(firstAddress).claim()
+
+      await ethers.provider.send('evm_increaseTime', [100001])
+      await deployedQuestContract.withdrawRemainingTokens(owner.address)
+
+      expect(await deployedSampleErc20Contract.balanceOf(deployedQuestContract.address)).to.equal(0)
+      // 1 is subtracted because the firstAddress claimed 1 token
+      expect(await deployedSampleErc20Contract.balanceOf(owner.address)).to.equal(totalRewardsPlusFee - 1)
+      await ethers.provider.send('evm_increaseTime', [-100001])
+      await ethers.provider.send('evm_increaseTime', [-86400])
     })
   })
 
-  describe('withDrawFee()', async () => {
+  describe('withdrawFee()', async () => {
     it('should transfer protocol fees back to owner', async () => {
-      // TODO test this better
-      // const beginningContractBalance = await deployedSampleErc20Contract.balanceOf(deployedQuestContract.address)
-      //
-      // await deployedRabbitholeReceiptContract.mint(owner.address, 1, questId)
-      // await deployedQuestContract.start()
-      //
-      // await ethers.provider.send('evm_increaseTime', [86400])
-      //
-      // const startingBalance = await deployedSampleErc20Contract.functions.balanceOf(protocolFeeAddress)
-      // expect(startingBalance.toString()).to.equal('0')
-      //
-      // await deployedQuestContract.claim()
-      //
-      // expect(beginningContractBalance.toString()).to.equal(totalRewardsPlusFee.toString())
-      // await ethers.provider.send('evm_increaseTime', [10001])
-      //
-      // await deployedQuestContract.withdrawFee()
-      //
-      // const endContactBalance = await deployedSampleErc20Contract.balanceOf(deployedQuestContract.address)
-      // expect(endContactBalance.toString()).to.equal('1188')
-      // const endOwnerBalance = await deployedSampleErc20Contract.balanceOf(protocolFeeAddress)
-      // expect(endOwnerBalance.toString()).to.equal('2')
-      // await ethers.provider.send('evm_increaseTime', [-10001])
-      // await ethers.provider.send('evm_increaseTime', [-86400])
+      const beginningContractBalance = await deployedSampleErc20Contract.balanceOf(deployedQuestContract.address)
+
+      await deployedFactoryContract.connect(firstAddress).mintReceipt(100, questId, messageHash, signature)
+      await deployedQuestContract.start()
+      await ethers.provider.send('evm_increaseTime', [86400])
+      expect(await deployedSampleErc20Contract.balanceOf(protocolFeeAddress)).to.equal(0)
+
+      await deployedQuestContract.connect(firstAddress).claim()
+      expect(await deployedSampleErc20Contract.balanceOf(firstAddress.address)).to.equal(100)
+      expect(beginningContractBalance).to.equal(totalRewardsPlusFee)
+
+      await ethers.provider.send('evm_increaseTime', [100001])
+      await deployedQuestContract.withdrawFee()
+
+      expect(await deployedSampleErc20Contract.balanceOf(deployedQuestContract.address)).to.equal(1100)
+      expect(await deployedSampleErc20Contract.balanceOf(protocolFeeAddress)).to.equal(0) // I don't think this math is correct
+
+      await ethers.provider.send('evm_increaseTime', [-100001])
+      await ethers.provider.send('evm_increaseTime', [-86400])
     })
   })
 })

--- a/test/Erc20Quest.spec.ts
+++ b/test/Erc20Quest.spec.ts
@@ -23,9 +23,9 @@ describe('Erc20Quest', async () => {
   const questId = 'asdf'
   const allowList = 'ipfs://someCidToAnArrayOfAddresses'
   const totalParticipants = 300
-  const totalRewardsPlusFee = 120000
   const rewardAmount = 1000
   const questFee = 2000
+  const totalRewardsPlusFee = totalParticipants * rewardAmount + (totalParticipants * rewardAmount * questFee / 10_000)
   let owner: SignerWithAddress
   let firstAddress: SignerWithAddress
   let secondAddress: SignerWithAddress
@@ -287,7 +287,7 @@ describe('Erc20Quest', async () => {
       expect(await deployedQuestContract.isClaimed(1)).to.equal(false)
 
       await deployedQuestContract.claim()
-      expect(await deployedSampleErc20Contract.balanceOf(owner.address)).to.equal(1000)
+      expect(await deployedSampleErc20Contract.balanceOf(owner.address)).to.equal(rewardAmount)
       await ethers.provider.send('evm_increaseTime', [-86400])
     })
 
@@ -329,15 +329,15 @@ describe('Erc20Quest', async () => {
 
       await deployedQuestContract.claim()
       const endingBalance = await deployedSampleErc20Contract.balanceOf(owner.address)
-      expect(endingBalance).to.equal(1000)
+      expect(endingBalance).to.equal(rewardAmount)
 
       await deployedQuestContract.connect(firstAddress).claim()
       const secondEndingBalance = await deployedSampleErc20Contract.balanceOf(firstAddress.address)
-      expect(secondEndingBalance).to.equal(1000)
+      expect(secondEndingBalance).to.equal(rewardAmount)
 
       await deployedQuestContract.connect(secondAddress).claim()
       const thirdEndingBalance = await deployedSampleErc20Contract.balanceOf(secondAddress.address)
-      expect(thirdEndingBalance).to.equal(1000)
+      expect(thirdEndingBalance).to.equal(rewardAmount)
 
       await ethers.provider.send('evm_increaseTime', [-86400])
     })

--- a/test/QuestFactory.spec.ts
+++ b/test/QuestFactory.spec.ts
@@ -100,7 +100,7 @@ describe('QuestFactory', () => {
         2000
       )
       await tx.wait()
-      const questAddress = await deployedFactoryContract.questAddressForQuestId(erc20QuestId)
+      const questAddress = await deployedFactoryContract.quests(erc20QuestId).then((res) => res.questAddress)
       const deployedErc20Quest = await ethers.getContractAt('Erc20Quest', questAddress)
       expect(await deployedErc20Quest.startTime()).to.equal(startDate)
       expect(await deployedErc20Quest.owner()).to.equal(owner.address)
@@ -119,7 +119,7 @@ describe('QuestFactory', () => {
         2000
       )
       await tx.wait()
-      const questAddress = await deployedFactoryContract.questAddressForQuestId(erc1155QuestId)
+      const questAddress = await deployedFactoryContract.quests(erc1155QuestId).then((res) => res.questAddress)
       const deployedErc1155Quest = await ethers.getContractAt('Erc1155Quest', questAddress)
       expect(await deployedErc1155Quest.startTime()).to.equal(startDate)
       expect(await deployedErc1155Quest.owner()).to.equal(owner.address)
@@ -228,30 +228,24 @@ describe('QuestFactory', () => {
     })
 
     it('Should mint a receipt', async () => {
-      await deployedFactoryContract.mintReceipt(1, erc20QuestId, messageHash, signature)
+      await deployedFactoryContract.mintReceipt(erc20QuestId, messageHash, signature)
       expect(await deployedRabbitHoleReceiptContract.balanceOf(owner.address)).to.equal(1)
     })
 
     it('Should fail if user tries to use a hash + signature that is not tied to them', async () => {
       await expect(
-        deployedFactoryContract.connect(royaltyRecipient).mintReceipt(1, erc20QuestId, messageHash, signature)
+        deployedFactoryContract.connect(royaltyRecipient).mintReceipt(erc20QuestId, messageHash, signature)
       ).to.be.revertedWithCustomError(questFactoryContract, 'InvalidHash')
     })
 
     it('Should fail if user is able to call mintReceipt multiple times', async () => {
-      await deployedFactoryContract.mintReceipt(1, erc20QuestId, messageHash, signature)
+      await deployedFactoryContract.mintReceipt(erc20QuestId, messageHash, signature)
       expect(await deployedRabbitHoleReceiptContract.balanceOf(owner.address)).to.equal(1)
 
       await expect(
-        deployedFactoryContract.mintReceipt(1, erc20QuestId, messageHash, signature)
+        deployedFactoryContract.mintReceipt(erc20QuestId, messageHash, signature)
       ).to.be.revertedWithCustomError(questFactoryContract, 'AddressAlreadyMinted')
       expect(await deployedRabbitHoleReceiptContract.balanceOf(owner.address)).to.equal(1)
-    })
-
-    it('Should not mint a number of receipts over the max allowed', async () => {
-      await expect(
-        deployedFactoryContract.mintReceipt(10001, erc20QuestId, messageHash, signature)
-      ).to.be.revertedWithCustomError(questFactoryContract, 'OverMaxAllowedToMint')
     })
   })
 })

--- a/test/RabbitHoleReceipt.spec.ts
+++ b/test/RabbitHoleReceipt.spec.ts
@@ -36,17 +36,17 @@ describe('RabbitholeReceipt Contract', async () => {
   })
 
   describe('mint', () => {
-    it('mints 5 tokens with correct questId', async () => {
-      await RHReceipt.connect(minterAddress).mint(firstAddress.address, 5, 'def456')
+    it('mints a token with correct questId', async () => {
+      await RHReceipt.connect(minterAddress).mint(firstAddress.address, 'def456')
 
-      expect(await RHReceipt.balanceOf(firstAddress.address)).to.eq(5)
+      expect(await RHReceipt.balanceOf(firstAddress.address)).to.eq(1)
       expect(await RHReceipt.questIdForTokenId(1)).to.eq('def456')
     })
   })
 
   describe('tokenURI', () => {
     it('has the correct metadata', async () => {
-      await RHReceipt.connect(minterAddress).mint(minterAddress.address, 1, 'abc123')
+      await RHReceipt.connect(minterAddress).mint(minterAddress.address, 'abc123')
       let base64encoded = await RHReceipt.tokenURI(1)
 
       let buff = Buffer.from(base64encoded.replace('data:application/json;base64,', ''), 'base64')
@@ -66,14 +66,14 @@ describe('RabbitholeReceipt Contract', async () => {
 
   describe('getOwnedTokenIdsOfQuest', () => {
     it('returns the correct tokenIds', async () => {
-      await RHReceipt.mint(contractOwner.address, 3, 'abc123')
-      await RHReceipt.mint(contractOwner.address, 2, 'def456')
-      await RHReceipt.mint(contractOwner.address, 4, 'eeeeee')
+      await RHReceipt.mint(contractOwner.address, 'abc123')
+      await RHReceipt.mint(contractOwner.address, 'def456')
+      await RHReceipt.mint(contractOwner.address, 'eeeeee')
 
       let tokenIds = await RHReceipt.getOwnedTokenIdsOfQuest('abc123', contractOwner.address)
 
-      expect(tokenIds.length).to.eq(3)
-      expect(tokenIds.map((tokenId: number) => tokenId.toNumber())).to.eql([1, 2, 3])
+      expect(tokenIds.length).to.eq(1)
+      expect(tokenIds[0].toNumber()).to.eql(1)
     })
   })
 })


### PR DESCRIPTION
- Removed quantity to mint
- Fixed math and logic around protocolFee
- Added `struct Quest` to the QuestFactory contract
- lots of small refactors
  - changed `totalAmount_` to `totalParticipants_,`
  - `withdrawRemainingTokens` now takes an address

This requires a redeploy of the receipt and factory contracts.