### PR TITLE
Prevent protocolFeeRecipient from being set to zero address

### DIFF
--- a/contracts/QuestFactory.sol
+++ b/contracts/QuestFactory.sol
@@ -21,6 +21,7 @@ contract QuestFactory is Initializable, OwnableUpgradeable, AccessControlUpgrade
     error OnlyOwnerCanCreate1155Quest();
     error RewardNotAllowed();
     error QuestTypeInvalid();
+    error AddressZeroNotAllowed();
 
     event QuestCreated(address indexed creator, address indexed contractAddress, string contractType);
 
@@ -49,6 +50,8 @@ contract QuestFactory is Initializable, OwnableUpgradeable, AccessControlUpgrade
         address rabbitholeReceiptContract_,
         address protocolFeeRecipient_
     ) public initializer {
+        if (protocolFeeRecipient_ == address(0)) revert AddressZeroNotAllowed();
+
         __Ownable_init();
         __AccessControl_init();
         grantDefaultAdminAndCreateQuestRole();
@@ -156,6 +159,7 @@ contract QuestFactory is Initializable, OwnableUpgradeable, AccessControlUpgrade
     /// @dev set the protocol fee recipient
     /// @param protocolFeeRecipient_ The address of the protocol fee recipient
     function setProtocolFeeRecipient(address protocolFeeRecipient_) public onlyOwner {
+        if (protocolFeeRecipient_ == address(0)) revert AddressZeroNotAllowed();
         protocolFeeRecipient = protocolFeeRecipient_;
     }
 

--- a/test/QuestFactory.spec.ts
+++ b/test/QuestFactory.spec.ts
@@ -8,7 +8,7 @@ import {
   SampleERC20__factory,
   SampleErc1155__factory,
 } from '../typechain-types'
-import { Wallet, utils } from 'ethers'
+import { Wallet, utils, constants } from 'ethers'
 
 describe('QuestFactory', () => {
   let deployedSampleErc20Contract: SampleERC20
@@ -78,6 +78,18 @@ describe('QuestFactory', () => {
       69,
     ])) as RabbitHoleReceipt
   }
+
+  describe('Deployment', () => {
+    it('Should revert if trying to deploy with protocolFeeRecipient set to zero address', async () => {
+      await expect(
+        upgrades.deployProxy(questFactoryContract, [
+          wallet.address,
+          deployedRabbitHoleReceiptContract.address,
+          constants.AddressZero,
+        ])
+      ).to.be.revertedWithCustomError(questFactoryContract, 'AddressZeroNotAllowed')
+    })
+  })
 
   describe('createQuest()', () => {
     const erc20QuestId = 'asdf'
@@ -268,6 +280,12 @@ describe('QuestFactory', () => {
       const newAddress = royaltyRecipient.address
       await deployedFactoryContract.setProtocolFeeRecipient(newAddress)
       expect(await deployedFactoryContract.protocolFeeRecipient()).to.equal(newAddress)
+    })
+
+    it('Should revert if setting protocolFeeRecipient to zero address', async () => {
+      await expect(
+        deployedFactoryContract.setProtocolFeeRecipient(constants.AddressZero)
+      ).to.be.revertedWithCustomError(questFactoryContract, 'AddressZeroNotAllowed')
     })
   })
 


### PR DESCRIPTION
https://linear.app/rh-app/issue/DEV-1301/protocolfeerecipient-check-this-is-not-address-0