### PR TITLE
Wumbo/check end time goes after start

### DIFF
--- a/contracts/Quest.sol
+++ b/contracts/Quest.sol
@@ -34,6 +34,7 @@ contract Quest is Ownable, IQuest {
     ) {
         if (endTime_ <= block.timestamp) revert EndTimeInPast();
         if (startTime_ <= block.timestamp) revert StartTimeInPast();
+        if (endTime_ <= startTime_) revert EndTimeLessThanOrEqualToStartTime();
         endTime = endTime_;
         startTime = startTime_;
         rewardToken = rewardTokenAddress_;

--- a/contracts/interfaces/IQuest.sol
+++ b/contracts/interfaces/IQuest.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity >=0.5.0;
+pragma solidity ^0.8.15;
 
 // TODO clean this whole thing up
 // Allows anyone to claim a token if they exist in a merkle root.

--- a/contracts/interfaces/IQuest.sol
+++ b/contracts/interfaces/IQuest.sol
@@ -11,6 +11,7 @@ interface IQuest {
     error NoTokensToClaim();
     error EndTimeInPast();
     error StartTimeInPast();
+    error EndTimeLessThanOrEqualToStartTime();
     error ClaimWindowNotStarted();
     error NoWithdrawDuringClaim();
     error TotalAmountExceedsBalance();

--- a/test/Erc1155Quest.spec.ts
+++ b/test/Erc1155Quest.spec.ts
@@ -10,7 +10,7 @@ import {
   RabbitHoleReceipt,
 } from '../typechain-types'
 
-describe('Erc1155Quest', () => {
+describe.only('Erc1155Quest', () => {
   let deployedQuestContract: Erc1155Quest
   let deployedSampleErc1155Contract: SampleErc1155
   let deployedRabbitholeReceiptContract: RabbitHoleReceipt
@@ -107,6 +107,14 @@ describe('Erc1155Quest', () => {
         expect(
           upgrades.deployProxy(questContract, [mockAddress, startDate - 1000, startDate, totalRewards])
         ).to.be.revertedWithCustomError(questContract, 'EndTimeInPast')
+      })
+    })
+
+    describe('when end time is before start time', () => {
+      it('Should revert', async () => {
+        expect(
+          upgrades.deployProxy(questContract, [mockAddress, startDate - 1000, startDate + 1000, totalRewards])
+        ).to.be.revertedWithCustomError(questContract, 'EndTimeLessThanOrEqualToStartTime')
       })
     })
 
@@ -287,16 +295,15 @@ describe('Erc1155Quest', () => {
 
   describe('withDraw()', async () => {
     it('should only allow the owner to withdraw', async () => {
-      await expect(deployedQuestContract.connect(firstAddress).withdrawRemainingTokens(owner.address)).to.be.revertedWith(
-        'Ownable: caller is not the owner'
-      )
+      await expect(
+        deployedQuestContract.connect(firstAddress).withdrawRemainingTokens(owner.address)
+      ).to.be.revertedWith('Ownable: caller is not the owner')
     })
 
     it('should revert if trying to withdraw before end date', async () => {
-      await expect(deployedQuestContract.connect(owner).withdrawRemainingTokens(owner.address)).to.be.revertedWithCustomError(
-        questContract,
-        'NoWithdrawDuringClaim'
-      )
+      await expect(
+        deployedQuestContract.connect(owner).withdrawRemainingTokens(owner.address)
+      ).to.be.revertedWithCustomError(questContract, 'NoWithdrawDuringClaim')
     })
 
     it('should transfer all rewards back to owner', async () => {

--- a/test/Erc1155Quest.spec.ts
+++ b/test/Erc1155Quest.spec.ts
@@ -10,7 +10,7 @@ import {
   RabbitHoleReceipt,
 } from '../typechain-types'
 
-describe.only('Erc1155Quest', () => {
+describe('Erc1155Quest', () => {
   let deployedQuestContract: Erc1155Quest
   let deployedSampleErc1155Contract: SampleErc1155
   let deployedRabbitholeReceiptContract: RabbitHoleReceipt

--- a/test/Erc20Quest.spec.ts
+++ b/test/Erc20Quest.spec.ts
@@ -13,7 +13,7 @@ import {
   QuestFactory__factory,
 } from '../typechain-types'
 
-describe('Erc20Quest', async () => {
+describe.only('Erc20Quest', async () => {
   let deployedQuestContract: Erc20Quest
   let deployedSampleErc20Contract: SampleERC20
   let deployedRabbitholeReceiptContract: RabbitHoleReceipt
@@ -147,6 +147,14 @@ describe('Erc20Quest', async () => {
         expect(
           upgrades.deployProxy(questContract, [mockAddress, startDate - 1000, startDate, totalParticipants])
         ).to.be.revertedWithCustomError(questContract, 'EndTimeInPast')
+      })
+    })
+
+    describe('when end time is before start time', () => {
+      it('Should revert', async () => {
+        expect(
+          upgrades.deployProxy(questContract, [mockAddress, startDate - 1000, startDate + 1000, totalParticipants])
+        ).to.be.revertedWithCustomError(questContract, 'EndTimeLessThanOrEqualToStartTime')
       })
     })
 

--- a/test/Erc20Quest.spec.ts
+++ b/test/Erc20Quest.spec.ts
@@ -13,7 +13,7 @@ import {
   QuestFactory__factory,
 } from '../typechain-types'
 
-describe.only('Erc20Quest', async () => {
+describe('Erc20Quest', async () => {
   let deployedQuestContract: Erc20Quest
   let deployedSampleErc20Contract: SampleERC20
   let deployedRabbitholeReceiptContract: RabbitHoleReceipt


### PR DESCRIPTION
https://linear.app/rh-app/issue/DEV-1321/outdated-compiler-version
https://linear.app/rh-app/issue/DEV-1304/constructor-ensure-endtime-starttime-otherwise-owner-can-rugpull-at