### PR TITLE
Modify event params

### DIFF
--- a/contracts/Quest.sol
+++ b/contracts/Quest.sol
@@ -115,7 +115,7 @@ contract Quest is OwnableUpgradeable, IQuest {
         _transferRewards(totalRedeemableRewards);
         redeemedTokens += redeemableTokenCount;
 
-        emit Claimed(msg.sender, totalRedeemableRewards);
+        emit Claimed(msg.sender, rewardToken, totalRedeemableRewards);
     }
 
     /// @notice Calculate the amount of rewards

--- a/contracts/QuestFactory.sol
+++ b/contracts/QuestFactory.sol
@@ -249,7 +249,7 @@ contract QuestFactory is Initializable, OwnableUpgradeable, AccessControlUpgrade
 
         quests[questId_].addressMinted[msg.sender] = true;
         quests[questId_].numberMinted++;
-        emit ReceiptMinted(msg.sender, questId_);
         rabbitHoleReceiptContract.mint(msg.sender, questId_);
+        emit ReceiptMinted(msg.sender, quests[questId_].questAddress, rabbitHoleReceiptContract.getTokenId(), questId_);
     }
 }

--- a/contracts/RabbitHoleReceipt.sol
+++ b/contracts/RabbitHoleReceipt.sol
@@ -56,7 +56,7 @@ contract RabbitHoleReceipt is
     }
 
     modifier onlyMinter() {
-        require(msg.sender == minterAddress, "Only minter");
+        require(msg.sender == minterAddress, 'Only minter');
         _;
     }
 
@@ -169,7 +169,20 @@ contract RabbitHoleReceipt is
         uint rewardAmount = questContract.getRewardAmount();
         address rewardAddress = questContract.getRewardToken();
 
-        return ReceiptRendererContract.generateTokenURI(tokenId_, questId, totalParticipants, claimed, rewardAmount, rewardAddress);
+        return
+            ReceiptRendererContract.generateTokenURI(
+                tokenId_,
+                questId,
+                totalParticipants,
+                claimed,
+                rewardAmount,
+                rewardAddress
+            );
+    }
+
+    /// @dev get the current token id
+    function getTokenId() public view returns (uint) {
+        return _tokenIds.current();
     }
 
     /// @dev See {IERC165-royaltyInfo}

--- a/contracts/interfaces/IQuest.sol
+++ b/contracts/interfaces/IQuest.sol
@@ -5,7 +5,7 @@ pragma solidity =0.8.16;
 // Allows anyone to claim a token if they exist in a merkle root.
 interface IQuest {
     // This event is triggered whenever a call to #claim succeeds.
-    event Claimed(address account, uint256 amount);
+    event Claimed(address account, address rewardAddress, uint256 amount);
 
     error AlreadyClaimed();
     error NoTokensToClaim();
@@ -21,6 +21,8 @@ interface IQuest {
     error MustImplementInChild();
 
     function isClaimed(uint256 tokenId_) external view returns (bool);
+
     function getRewardAmount() external view returns (uint256);
+
     function getRewardToken() external view returns (address);
 }

--- a/contracts/interfaces/IQuestFactory.sol
+++ b/contracts/interfaces/IQuestFactory.sol
@@ -15,8 +15,18 @@ interface IQuestFactory {
     error QuestNotStarted();
     error QuestEnded();
 
-    event QuestCreated(address indexed creator, address indexed contractAddress, string indexed questId, string contractType, address rewardTokenAddress, uint256 endTime, uint256 startTime, uint256 totalParticipants, uint256 rewardAmountOrTokenId);
-    event ReceiptMinted(address indexed recipient, string indexed questId);
+    event QuestCreated(
+        address indexed creator,
+        address indexed contractAddress,
+        string questId,
+        string contractType,
+        address rewardTokenAddress,
+        uint256 endTime,
+        uint256 startTime,
+        uint256 totalParticipants,
+        uint256 rewardAmountOrTokenId
+    );
+    event ReceiptMinted(address indexed recipient, address indexed questAddress, uint indexed tokenId, string questId);
 
     function questInfo(string memory questId_) external view returns (address, uint, uint);
 }


### PR DESCRIPTION
Adds more details to the events that we care about. Removed indexes on `questId` as it turns into a hash and it's difficult to parse the actual value