### PR TITLE
🔥Quest: queue&createQueue

### DIFF
--- a/contracts/Quest.sol
+++ b/contracts/Quest.sol
@@ -68,8 +68,6 @@ contract Quest is ReentrancyGuardUpgradeable, PausableUpgradeable, Ownable, IQue
         protocolFeeRecipient = protocolFeeRecipient_;
         durationTotal = durationTotal_;
         queued = true;
-        // Note: Not sure if this is needed; figured I'd include it incase we're watching for it but easy to remove
-        emit Queued(block.timestamp);
         _initializeOwner(msg.sender);
         __Pausable_init();
         __ReentrancyGuard_init();

--- a/contracts/Quest.sol
+++ b/contracts/Quest.sol
@@ -67,6 +67,9 @@ contract Quest is ReentrancyGuardUpgradeable, PausableUpgradeable, Ownable, IQue
         hasWithdrawn = false;
         protocolFeeRecipient = protocolFeeRecipient_;
         durationTotal = durationTotal_;
+        queued = true;
+        // Note: Not sure if this is needed; figured I'd include it incase we're watching for it but easy to remove
+        emit Queued(block.timestamp);
         _initializeOwner(msg.sender);
         __Pausable_init();
         __ReentrancyGuard_init();
@@ -77,24 +80,15 @@ contract Quest is ReentrancyGuardUpgradeable, PausableUpgradeable, Ownable, IQue
         return this.maxTotalRewards() + this.maxProtocolReward();
     }
 
-    /// @notice Queues the quest by marking it ready to start at the contract level. Marking a quest as queued does not mean that it is live. It also requires that the start time has passed
-    /// @dev Requires that the balance of the rewards in the contract is greater than or equal to the maximum amount of rewards that can be claimed by all users and the protocol
-    function queue() public virtual onlyOwner {
-        if (rewardToken.balanceOf(address(this)) < this.totalTransferAmount())
-            revert TotalAmountExceedsBalance();
-        queued = true;
-        emit Queued(block.timestamp);
-    }
-
     /// @notice Pauses the Quest
     /// @dev Only the owner of the Quest can call this function. Also requires that the Quest has started (not by date, but by calling the start function)
-    function pause() external onlyOwner onlyStarted {
+    function pause() external onlyOwner {
         _pause();
     }
 
     /// @notice Unpauses the Quest
     /// @dev Only the owner of the Quest can call this function. Also requires that the Quest has started (not by date, but by calling the start function)
-    function unPause() external onlyOwner onlyStarted {
+    function unPause() external onlyOwner {
         _unpause();
     }
 
@@ -104,15 +98,8 @@ contract Quest is ReentrancyGuardUpgradeable, PausableUpgradeable, Ownable, IQue
         _;
     }
 
-    /// @notice Checks if the Quest has started at the function level
-    modifier onlyStarted() {
-        if (!queued) revert NotStarted();
-        _;
-    }
-
     /// @notice Checks if quest has started both at the function level and at the start time
     modifier onlyQuestActive() {
-        if (!queued) revert NotStarted();
         if (block.timestamp < startTime) revert ClaimWindowNotStarted();
         _;
     }

--- a/contracts/QuestFactory.sol
+++ b/contracts/QuestFactory.sol
@@ -235,40 +235,6 @@ contract QuestFactory is Initializable, OwnableUpgradeable, AccessControlUpgrade
         QuestContract(newQuest_).queue();
     }
 
-    /// @dev Create an erc20 quest
-    /// @param rewardTokenAddress_ The contract address of the reward token
-    /// @param endTime_ The end time of the quest
-    /// @param startTime_ The start time of the quest
-    /// @param totalParticipants_ The total amount of participants (accounts) the quest will have
-    /// @param rewardAmount_ The reward amount for an erc20 quest
-    /// @param questId_ The id of the quest
-    /// @return address the quest contract address
-    function createQuest(
-        address rewardTokenAddress_,
-        uint256 endTime_,
-        uint256 startTime_,
-        uint256 totalParticipants_,
-        uint256 rewardAmount_,
-        string memory, // was contractType_ , currently deprecated.
-        string memory questId_
-    ) external checkQuest(questId_, rewardTokenAddress_) returns (address) {
-        address newQuest = createERC20QuestInternal(
-            rewardTokenAddress_,
-            endTime_,
-            startTime_,
-            totalParticipants_,
-            rewardAmount_,
-            questId_,
-            0,
-            "",
-            0
-        );
-
-        QuestContract(newQuest).transferOwnership(msg.sender);
-
-        return newQuest;
-    }
-
     /// @dev Create a sablier stream reward quest and start it at the same time.
     /// @notice The function will transfer the reward amount to the quest contract
     /// @param rewardTokenAddress_ The contract address of the reward token

--- a/contracts/QuestFactory.sol
+++ b/contracts/QuestFactory.sol
@@ -230,9 +230,11 @@ contract QuestFactory is Initializable, OwnableUpgradeable, AccessControlUpgrade
     /// @dev Contract must be approved to transfer first
     /// @param newQuest_ The address of the new quest
     /// @param rewardTokenAddress_ The contract address of the reward token
-    function transferTokensAndQueueQuest(address newQuest_, address rewardTokenAddress_) internal {
-        rewardTokenAddress_.safeTransferFrom(msg.sender, newQuest_, QuestContract(newQuest_).totalTransferAmount());
-        QuestContract(newQuest_).queue();
+    function transferTokensAndOwnership(address newQuest_, address rewardTokenAddress_) internal {
+        address sender = msg.sender;
+        QuestContract questContract = QuestContract(newQuest_);
+        rewardTokenAddress_.safeTransferFrom(sender, newQuest_, questContract.totalTransferAmount());
+        questContract.transferOwnership(sender);
     }
 
     /// @dev Create a sablier stream reward quest and start it at the same time.
@@ -269,10 +271,7 @@ contract QuestFactory is Initializable, OwnableUpgradeable, AccessControlUpgrade
             actionSpec_,
             durationTotal_
         );
-
-        transferTokensAndQueueQuest(newQuest, rewardTokenAddress_);
-        QuestContract(newQuest).transferOwnership(msg.sender);
-
+        transferTokensAndOwnership(newQuest, rewardTokenAddress_);
         return newQuest;
     }
 
@@ -307,10 +306,7 @@ contract QuestFactory is Initializable, OwnableUpgradeable, AccessControlUpgrade
             actionSpec_,
             0
         );
-
-        transferTokensAndQueueQuest(newQuest, rewardTokenAddress_);
-        QuestContract(newQuest).transferOwnership(msg.sender);
-
+        transferTokensAndOwnership(newQuest, rewardTokenAddress_);
         return newQuest;
     }
 

--- a/test/Quest.spec.ts
+++ b/test/Quest.spec.ts
@@ -179,15 +179,6 @@ describe('Quest', async () => {
     })
   })
 
-  describe('queue()', () => {
-    it('should only allow the owner to start', async () => {
-      await expect(deployedQuestContract.connect(firstAddress).queue()).to.be.revertedWithCustomError(
-        questContract,
-        'Unauthorized'
-      )
-    })
-  })
-
   describe('pause()', () => {
     it('should only allow the owner to pause', async () => {
       await expect(deployedQuestContract.connect(firstAddress).pause()).to.be.revertedWithCustomError(

--- a/test/Quest.spec.ts
+++ b/test/Quest.spec.ts
@@ -165,7 +165,7 @@ describe('Quest', async () => {
 
       it('Should set has started with correct value', async () => {
         const queued = await deployedQuestContract.queued()
-        expect(queued).to.equal(false)
+        expect(queued).to.equal(true) // New default behavior is to queue quests on creation - this will be removed in follow-on
       })
 
       it('Should set the end time with correct value', async () => {

--- a/test/Quest.spec.ts
+++ b/test/Quest.spec.ts
@@ -79,7 +79,6 @@ describe('Quest', async () => {
     let questAddress = await deployedFactoryContract.quests(questId).then((res) => res.questAddress)
     deployedQuestContract = await ethers.getContractAt('Quest', questAddress)
 
-    await transferRewardsToDistributor()
   })
 
   const deployFactoryContract = async () => {
@@ -103,14 +102,10 @@ describe('Quest', async () => {
     deployedSampleErc20Contract = await sampleERC20Contract.deploy(
       'RewardToken',
       'RTC',
-      '1000000',
+      totalRewardsPlusFee,
       owner.address
     )
     await deployedSampleErc20Contract.deployed()
-  }
-
-  const transferRewardsToDistributor = async () => {
-    await deployedSampleErc20Contract.functions.transfer(deployedQuestContract.address, totalRewardsPlusFee)
   }
 
   describe('Deployment', () => {

--- a/test/Quest.spec.ts
+++ b/test/Quest.spec.ts
@@ -191,12 +191,6 @@ describe('Quest', async () => {
         'Unauthorized'
       )
     })
-
-    it('should set start correctly', async () => {
-      expect(await deployedQuestContract.queued()).to.equal(false)
-      await deployedQuestContract.connect(owner).queue()
-      expect(await deployedQuestContract.queued()).to.equal(true)
-    })
   })
 
   describe('pause()', () => {

--- a/test/Quest.spec.ts
+++ b/test/Quest.spec.ts
@@ -284,7 +284,6 @@ describe('Quest', async () => {
 
   describe('singleClaim()', async () => {
     beforeEach(async () => {
-      await deployedQuestContract.queue()
       await time.increaseTo(startDate)
     })
 

--- a/test/Quest.spec.ts
+++ b/test/Quest.spec.ts
@@ -202,8 +202,6 @@ describe('Quest', async () => {
     })
 
     it('should set pause correctly', async () => {
-      expect(await deployedQuestContract.queued()).to.equal(false)
-      await deployedQuestContract.connect(owner).queue()
       expect(await deployedQuestContract.paused()).to.equal(false)
       await deployedQuestContract.connect(owner).pause()
       expect(await deployedQuestContract.paused()).to.equal(true)
@@ -219,9 +217,7 @@ describe('Quest', async () => {
     })
 
     it('should set unPause correctly', async () => {
-      expect(await deployedQuestContract.queued()).to.equal(false)
-      expect(await deployedQuestContract.paused()).to.equal(false)
-      await deployedQuestContract.connect(owner).queue()
+      expect(await deployedQuestContract.queued()).to.equal(true)
       expect(await deployedQuestContract.paused()).to.equal(false)
       await deployedQuestContract.connect(owner).pause()
       expect(await deployedQuestContract.paused()).to.equal(true)

--- a/test/Quest.spec.ts
+++ b/test/Quest.spec.ts
@@ -238,7 +238,6 @@ describe('Quest', async () => {
     })
 
     it('should transfer non-claimable rewards back to owner and protocol fees to protocolFeeAddress - called from owner', async () => {
-      await deployedQuestContract.queue()
       await time.setNextBlockTimestamp(startDate + 1)
       await deployedFactoryContract.connect(firstAddress).claimRewards(questId, messageHash, signature)
       expect(await deployedSampleErc20Contract.balanceOf(protocolFeeRecipient.address)).to.equal(0)
@@ -261,7 +260,6 @@ describe('Quest', async () => {
     })
 
     it('should transfer non-claimable rewards back to owner and protocol fees to protocolFeeAddress - called from protocolFeeRecipient', async () => {
-      await deployedQuestContract.queue()
       await time.setNextBlockTimestamp(startDate + 1)
       await deployedFactoryContract.connect(firstAddress).claimRewards(questId, messageHash, signature)
       expect(await deployedSampleErc20Contract.balanceOf(protocolFeeRecipient.address)).to.equal(0)

--- a/test/QuestFactory.spec.ts
+++ b/test/QuestFactory.spec.ts
@@ -123,16 +123,18 @@ describe('QuestFactory', () => {
     it('Should revert if reward address is not on the reward allowlist', async () => {
       const rewardAddress = deployedSampleErc20Contract.address
       expect(await deployedFactoryContract.rewardAllowlist(rewardAddress)).to.equal(false)
+      await deployedSampleErc20Contract.approve(deployedFactoryContract.address, transferAmount)
 
       await expect(
-        deployedFactoryContract.createQuest(
+        deployedFactoryContract.createQuestAndQueue(
           deployedSampleErc20Contract.address,
           expiryDate,
           startDate,
           totalRewards,
           rewardAmount,
-          'erc20',
-          erc20QuestId
+          erc20QuestId,
+          '', // actionSpec
+          0   // discountTokenId
         )
       ).to.be.revertedWithCustomError(questFactoryContract, 'RewardNotAllowed')
     })
@@ -179,6 +181,7 @@ describe('QuestFactory', () => {
 
     it('Should revert if trying to use existing quest id', async () => {
       await deployedFactoryContract.setRewardAllowlistAddress(deployedSampleErc20Contract.address, true)
+      await deployedSampleErc20Contract.approve(deployedFactoryContract.address, transferAmount)
 
       await deployedFactoryContract.createQuestAndQueue(
         deployedSampleErc20Contract.address,

--- a/test/QuestFactory.spec.ts
+++ b/test/QuestFactory.spec.ts
@@ -180,25 +180,27 @@ describe('QuestFactory', () => {
     it('Should revert if trying to use existing quest id', async () => {
       await deployedFactoryContract.setRewardAllowlistAddress(deployedSampleErc20Contract.address, true)
 
-      await deployedFactoryContract.createQuest(
+      await deployedFactoryContract.createQuestAndQueue(
         deployedSampleErc20Contract.address,
         expiryDate,
         startDate,
         totalRewards,
         rewardAmount,
-        'erc20',
-        erc20QuestId
+        erc20QuestId,
+        '', // actionSpec
+        0   // discountTokenId
       )
 
       await expect(
-        deployedFactoryContract.createQuest(
+        deployedFactoryContract.createQuestAndQueue(
           deployedSampleErc20Contract.address,
           expiryDate,
           startDate,
           totalRewards,
           rewardAmount,
-          'erc20',
-          erc20QuestId
+          erc20QuestId,
+          '', // actionSpec
+          0   // discountTokenId
         )
       ).to.be.revertedWithCustomError(questFactoryContract, 'QuestIdUsed')
     })

--- a/test/QuestFactory.spec.ts
+++ b/test/QuestFactory.spec.ts
@@ -555,7 +555,6 @@ describe('QuestFactory', () => {
     it('should succeed if the mint fee is equal or greator than required amount, and only recieve the required amount', async function () {
       const requiredFee = 1000
       const extraChange = 100
-      await erc20Quest.queue()
       await deployedFactoryContract.setMintFee(requiredFee)
       await time.setNextBlockTimestamp(startDate)
       const balanceBefore = await ethers.provider.getBalance(deployedFactoryContract.getMintFeeRecipient())
@@ -582,7 +581,6 @@ describe('QuestFactory', () => {
       const requiredFee = 1000
       const extraChange = 100
       const referralAmount = (requiredFee * referralFee) / 10_000
-      await erc20Quest.queue()
       await deployedFactoryContract.setMintFee(requiredFee)
       await time.setNextBlockTimestamp(startDate)
       const mintFeeRecipientBalanceBefore = await ethers.provider.getBalance(

--- a/test/QuestFactory.spec.ts
+++ b/test/QuestFactory.spec.ts
@@ -400,21 +400,24 @@ describe('QuestFactory', () => {
 
     it('Should return the correct quest data for erc20 quest', async () => {
       await deployedFactoryContract.setRewardAllowlistAddress(deployedSampleErc20Contract.address, true)
-      await deployedFactoryContract.createQuest(
+      await deployedSampleErc20Contract.approve(deployedFactoryContract.address, transferAmount)
+
+      await deployedFactoryContract.createQuestAndQueue(
         deployedSampleErc20Contract.address,
         expiryDate,
         startDate,
         totalRewards,
         rewardAmount,
-        'erc20',
-        erc20QuestId
+        erc20QuestId,
+        '', // actionSpec
+        0   // discountTokenId
       )
       const questAddress = await deployedFactoryContract.quests(erc20QuestId).then((res) => res.questAddress)
       const questData = await deployedFactoryContract.questData(erc20QuestId)
       expect(questData).to.eql([
         questAddress,
         deployedSampleErc20Contract.address,
-        false,
+        true, // Queued now defaults to true
         2000, // questFee
         ethers.BigNumber.from(startDate),
         ethers.BigNumber.from(expiryDate),

--- a/test/QuestFactory.spec.ts
+++ b/test/QuestFactory.spec.ts
@@ -220,17 +220,20 @@ describe('QuestFactory', () => {
 
     it('Should allow anyone to create a quest', async () => {
       await deployedFactoryContract.setRewardAllowlistAddress(deployedSampleErc20Contract.address, true)
+      await deployedSampleErc20Contract.transfer(royaltyRecipient.address, transferAmount)
+      await deployedSampleErc20Contract.connect(royaltyRecipient).approve(deployedFactoryContract.address, transferAmount)
 
       const tx = await deployedFactoryContract
         .connect(royaltyRecipient)
-        .createQuest(
+        .createQuestAndQueue(
           deployedSampleErc20Contract.address,
           expiryDate,
           startDate,
           totalRewards,
           rewardAmount,
-          'erc20',
-          erc20QuestId
+          erc20QuestId,
+          '', // actionSpec
+          0   // discountTokenId
         )
       await tx.wait()
       const questAddress = await deployedFactoryContract.quests(erc20QuestId).then((res) => res.questAddress)

--- a/test/QuestFactory.spec.ts
+++ b/test/QuestFactory.spec.ts
@@ -173,16 +173,18 @@ describe('QuestFactory', () => {
       await deployedFactoryContract.setRewardAllowlistAddress(deployedSampleErc20Contract.address, false)
 
       expect(await deployedFactoryContract.rewardAllowlist(rewardAddress)).to.equal(false)
+      await deployedSampleErc20Contract.approve(deployedFactoryContract.address, transferAmount)
 
       await expect(
-        deployedFactoryContract.createQuest(
+        deployedFactoryContract.createQuestAndQueue(
           deployedSampleErc20Contract.address,
           expiryDate,
           startDate,
           totalRewards,
           rewardAmount,
-          'erc20',
-          erc20QuestId
+          erc20QuestId,
+          '', // actionSpec
+          0   // discountTokenId
         )
       ).to.be.revertedWithCustomError(questFactoryContract, 'RewardNotAllowed')
     })


### PR DESCRIPTION
First half of the PR is the removal of the `createQuest` and the corresponding modifications to the test to get them back to passing, then I pulled the actual `queue` function off of `Quest.sol`.

As it stands now, I just set the `queued` bool in the initialize and fire off the `Queued` event right in that function, but we could leave `queued` false and remove the event pretty easily assuming nothing is listening for, or checking that variable.

[Here's the main logic change](https://github.com/rabbitholegg/quest-protocol/commit/8cef6d6855dfdd6ffb1a7e8d84b7e4432aba5c7f) in `QuestFactory` to accommodate the lack of `queue` and [here's where I removed the actual `queue` function](https://github.com/rabbitholegg/quest-protocol/commit/6e01545ce612e7cc93603a02ca1f5f5d188a1d20). Everything else is pretty straight forward.