### PR TITLE
🎨QuestFactory&Quest: use interfaces vs instances

### DIFF
--- a/contracts/Quest.sol
+++ b/contracts/Quest.sol
@@ -1,15 +1,18 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.18;
 
+// Inherits
+import {Ownable} from 'solady/src/auth/Ownable.sol';
 import {PausableUpgradeable} from '@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol';
 import {ReentrancyGuardUpgradeable} from '@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol';
-import {Ownable} from 'solady/src/auth/Ownable.sol';
-import {SafeTransferLib} from 'solady/src/utils/SafeTransferLib.sol';
-import {QuestFactory} from './QuestFactory.sol';
+// Implements
 import {IQuest} from './interfaces/IQuest.sol';
-
-import { ISablierV2LockupLinear } from "@sablier/v2-core/src/interfaces/ISablierV2LockupLinear.sol";
+// Leverages
+import {SafeTransferLib} from 'solady/src/utils/SafeTransferLib.sol';
 import { LockupLinear } from "@sablier/v2-core/src/types/DataTypes.sol";
+// References
+import {QuestFactory} from './QuestFactory.sol';
+import { ISablierV2LockupLinear } from "@sablier/v2-core/src/interfaces/ISablierV2LockupLinear.sol";
 import { IERC20 } from "@sablier/v2-core/src/types/Tokens.sol";
 
 /// @title Quest

--- a/contracts/Quest.sol
+++ b/contracts/Quest.sol
@@ -11,7 +11,7 @@ import {IQuest} from './interfaces/IQuest.sol';
 import {SafeTransferLib} from 'solady/src/utils/SafeTransferLib.sol';
 import { LockupLinear } from "@sablier/v2-core/src/types/DataTypes.sol";
 // References
-import {QuestFactory} from './QuestFactory.sol';
+import { IQuestFactory } from './interfaces/IQuestFactory.sol';
 import { ISablierV2LockupLinear } from "@sablier/v2-core/src/interfaces/ISablierV2LockupLinear.sol";
 import { IERC20 } from "@sablier/v2-core/src/types/Tokens.sol";
 
@@ -21,7 +21,7 @@ import { IERC20 } from "@sablier/v2-core/src/types/Tokens.sol";
 contract Quest is ReentrancyGuardUpgradeable, PausableUpgradeable, Ownable, IQuest {
     using SafeTransferLib for address;
     address public rabbitHoleReceiptContract;    // Deprecated - do not use
-    QuestFactory public questFactoryContract;
+    IQuestFactory public questFactoryContract;
     address public rewardToken;
     uint256 public endTime;
     uint256 public startTime;
@@ -64,7 +64,7 @@ contract Quest is ReentrancyGuardUpgradeable, PausableUpgradeable, Ownable, IQue
         totalParticipants = totalParticipants_;
         rewardAmountInWei = rewardAmountInWei_;
         questId = questId_;
-        questFactoryContract = QuestFactory(payable(msg.sender));
+        questFactoryContract = IQuestFactory(payable(msg.sender));
         sablierV2LockupLinearContract = ISablierV2LockupLinear(sablierV2LockupLinearAddress_);
         questFee = questFee_;
         hasWithdrawn = false;

--- a/contracts/Quest1155.sol
+++ b/contracts/Quest1155.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.18;
 
 import {IERC1155} from '@openzeppelin/contracts/token/ERC1155/IERC1155.sol';
+import {IQuest1155} from './interfaces/IQuest1155.sol';
 import {ERC1155Holder} from '@openzeppelin/contracts/token/ERC1155/utils/ERC1155Holder.sol';
 import {PausableUpgradeable} from '@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol';
 import {ReentrancyGuardUpgradeable} from "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol";
@@ -13,7 +14,7 @@ import {QuestFactory} from './QuestFactory.sol';
 /// @author RabbitHole.gg
 /// @notice This contract is the Erc1155Quest contract. It is a quest that is redeemable for ERC1155 tokens.
 /// @dev This contract will not work with RabbitHoleReceipt
-contract Quest1155 is ERC1155Holder, ReentrancyGuardUpgradeable, PausableUpgradeable, Ownable {
+contract Quest1155 is ERC1155Holder, ReentrancyGuardUpgradeable, PausableUpgradeable, Ownable, IQuest1155 {
     using SafeTransferLib for address;
 
     QuestFactory public questFactoryContract;
@@ -32,20 +33,6 @@ contract Quest1155 is ERC1155Holder, ReentrancyGuardUpgradeable, PausableUpgrade
     constructor() {
         _disableInitializers();
     }
-
-    error EndTimeInPast();
-    error EndTimeLessThanOrEqualToStartTime();
-    error InsufficientTokenBalance();
-    error InsufficientETHBalance();
-    error NotStarted();
-    error NotEnded();
-    error NotQueued();
-    error NotQuestFactory();
-    error QuestEnded();
-    error AlreadyWithdrawn();
-
-    event ClaimedSingle(address indexed account, address rewardAddress, uint amount);
-    event Queued(uint timestamp);
 
     function initialize(
         address rewardTokenAddress_,

--- a/contracts/QuestFactory.sol
+++ b/contracts/QuestFactory.sol
@@ -1,20 +1,24 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.18;
 
+// Inherits
 import {Initializable} from '@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol';
+import {OwnableUpgradeable} from './OwnableUpgradeable.sol';
 import {AccessControlUpgradeable} from '@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol';
-import {IERC1155} from '@openzeppelin/contracts/token/ERC1155/IERC1155.sol';
+// Implements
+import {IQuestFactory} from './interfaces/IQuestFactory.sol';
+// Leverages
 import {ECDSA} from 'solady/src/utils/ECDSA.sol';
 import {LibClone} from 'solady/src/utils/LibClone.sol';
 import {LibString} from 'solady/src/utils/LibString.sol';
 import {SafeTransferLib} from 'solady/src/utils/SafeTransferLib.sol';
-import {IQuestFactory} from './interfaces/IQuestFactory.sol';
+// References
+import {IERC1155} from '@openzeppelin/contracts/token/ERC1155/IERC1155.sol';
 import {IQuest} from './interfaces/IQuest.sol';
 import {IQuest1155} from './interfaces/IQuest1155.sol';
-import {Quest as QuestContract} from './Quest.sol';
-import {Quest1155 as Quest1155Contract} from './Quest1155.sol';
-import {OwnableUpgradeable} from './OwnableUpgradeable.sol';
-import {QuestTerminalKey} from "./QuestTerminalKey.sol";
+import {Quest as QuestContract} from './Quest.sol'; // Collapse into interface
+import {Quest1155 as Quest1155Contract} from './Quest1155.sol'; // Collapse into interface
+import {QuestTerminalKey} from "./QuestTerminalKey.sol"; // Collapse into interface
 
 /// @title QuestFactory
 /// @author RabbitHole.gg

--- a/contracts/QuestFactory.sol
+++ b/contracts/QuestFactory.sol
@@ -14,9 +14,8 @@ import {LibString} from 'solady/src/utils/LibString.sol';
 import {SafeTransferLib} from 'solady/src/utils/SafeTransferLib.sol';
 // References
 import {IERC1155} from '@openzeppelin/contracts/token/ERC1155/IERC1155.sol';
-import {IQuest} from './interfaces/IQuest.sol';
+import {IQuestOwnable} from './interfaces/IQuestOwnable.sol';
 import {IQuest1155} from './interfaces/IQuest1155.sol';
-import {Quest as QuestContract} from './Quest.sol'; // Collapse into interface
 import {Quest1155 as Quest1155Contract} from './Quest1155.sol'; // Collapse into interface
 import {QuestTerminalKey} from "./QuestTerminalKey.sol"; // Collapse into interface
 
@@ -205,7 +204,7 @@ contract QuestFactory is Initializable, OwnableUpgradeable, AccessControlUpgrade
             protocolFee = doDiscountedFee(discountTokenId_);
         }
 
-        QuestContract(newQuest).initialize(
+        IQuestOwnable(newQuest).initialize(
             rewardTokenAddress_,
             endTime_,
             startTime_,
@@ -236,7 +235,7 @@ contract QuestFactory is Initializable, OwnableUpgradeable, AccessControlUpgrade
     /// @param rewardTokenAddress_ The contract address of the reward token
     function transferTokensAndOwnership(address newQuest_, address rewardTokenAddress_) internal {
         address sender = msg.sender;
-        QuestContract questContract = QuestContract(newQuest_);
+        IQuestOwnable questContract = IQuestOwnable(newQuest_);
         rewardTokenAddress_.safeTransferFrom(sender, newQuest_, questContract.totalTransferAmount());
         questContract.transferOwnership(sender);
     }
@@ -491,7 +490,7 @@ contract QuestFactory is Initializable, OwnableUpgradeable, AccessControlUpgrade
     /// @param questId_ The id of the quest
     function questData(string memory questId_) external view returns (QuestData memory) {
         Quest storage thisQuest = quests[questId_];
-        QuestContract questContract = QuestContract(thisQuest.questAddress);
+        IQuestOwnable questContract = IQuestOwnable(thisQuest.questAddress);
         uint rewardAmountOrTokenId;
         uint16 erc20QuestFee;
 
@@ -574,7 +573,7 @@ contract QuestFactory is Initializable, OwnableUpgradeable, AccessControlUpgrade
     /// @param ref_ The referral address
     function claimRewardsRef(string memory questId_, bytes32 hash_, bytes memory signature_, address ref_) private nonReentrant sufficientMintFee claimChecks(questId_, hash_, signature_, ref_) {
         Quest storage currentQuest = quests[questId_];
-        IQuest questContract_ = IQuest(currentQuest.questAddress);
+        IQuestOwnable questContract_ = IQuestOwnable(currentQuest.questAddress);
         if (!questContract_.queued()) revert QuestNotQueued();
         if (block.timestamp < questContract_.startTime()) revert QuestNotStarted();
         if (block.timestamp > questContract_.endTime()) revert QuestEnded();

--- a/contracts/QuestFactory.sol
+++ b/contracts/QuestFactory.sol
@@ -28,14 +28,6 @@ contract QuestFactory is Initializable, OwnableUpgradeable, AccessControlUpgrade
     using LibString for uint256;
 
     // storage vars. Insert new vars at the end to keep the storage layout the same.
-    struct Quest {
-        mapping(address => bool) addressMinted;
-        address questAddress;
-        uint totalParticipants;
-        uint numberMinted;
-        string questType;
-        uint40 durationTotal;
-    }
     address public claimSignerAddress;
     address public protocolFeeRecipient;
     address public erc20QuestAddress;
@@ -51,27 +43,8 @@ contract QuestFactory is Initializable, OwnableUpgradeable, AccessControlUpgrade
     IQuestTerminalKeyERC721 private questTerminalKeyContract;
     uint public nftQuestFee;
     address public questNFTAddress;
-    struct QuestData {
-        address questAddress;
-        address rewardToken;
-        bool queued;
-        uint16 questFee;
-        uint startTime;
-        uint endTime;
-        uint totalParticipants;
-        uint numberMinted;
-        uint redeemedTokens;
-        uint rewardAmountOrTokenId;
-        bool hasWithdrawn;
-        string questType;
-        uint40 durationTotal;
-    }
     mapping(address => address[]) public ownerCollections;
     mapping(address => NftQuestFees) public nftQuestFeeList;
-    struct NftQuestFees {
-        uint256 fee;
-        bool exists;
-    }
     uint16 public referralFee;
     address public sablierV2LockupLinearAddress;
 

--- a/contracts/QuestFactory.sol
+++ b/contracts/QuestFactory.sol
@@ -17,7 +17,7 @@ import {IERC1155} from '@openzeppelin/contracts/token/ERC1155/IERC1155.sol';
 import {IQuestOwnable} from './interfaces/IQuestOwnable.sol';
 import {IQuest1155} from './interfaces/IQuest1155.sol';
 import {Quest1155 as Quest1155Contract} from './Quest1155.sol'; // Collapse into interface
-import {QuestTerminalKey} from "./QuestTerminalKey.sol"; // Collapse into interface
+import {IQuestTerminalKeyERC721} from "./interfaces/IQuestTerminalKeyERC721.sol"; 
 
 /// @title QuestFactory
 /// @author RabbitHole.gg
@@ -49,7 +49,7 @@ contract QuestFactory is Initializable, OwnableUpgradeable, AccessControlUpgrade
     uint public mintFee;
     address public mintFeeRecipient;
     uint256 private locked;
-    QuestTerminalKey private questTerminalKeyContract;
+    IQuestTerminalKeyERC721 private questTerminalKeyContract;
     uint public nftQuestFee;
     address public questNFTAddress;
     struct QuestData {
@@ -98,7 +98,7 @@ contract QuestFactory is Initializable, OwnableUpgradeable, AccessControlUpgrade
         protocolFeeRecipient = protocolFeeRecipient_;
         erc20QuestAddress = erc20QuestAddress_;
         erc1155QuestAddress = erc1155QuestAddress_;
-        questTerminalKeyContract = QuestTerminalKey(questTerminalKeyAddress_);
+        questTerminalKeyContract = IQuestTerminalKeyERC721(questTerminalKeyAddress_);
         sablierV2LockupLinearAddress = sablierV2LockupLinearAddress_;
         nftQuestFee = nftQuestFee_;
         referralFee = referralFee_;
@@ -452,7 +452,7 @@ contract QuestFactory is Initializable, OwnableUpgradeable, AccessControlUpgrade
     /// @dev set questTerminalKeyContract address
     /// @param questTerminalKeyContract_ The address of the questTerminalKeyContract
     function setQuestTerminalKeyContract(address questTerminalKeyContract_) external onlyOwner {
-        questTerminalKeyContract = QuestTerminalKey(questTerminalKeyContract_);
+        questTerminalKeyContract = IQuestTerminalKeyERC721(questTerminalKeyContract_);
     }
 
     /// @dev set or remave a contract address to be used as a reward

--- a/contracts/QuestTerminalKey.sol
+++ b/contracts/QuestTerminalKey.sol
@@ -36,10 +36,7 @@ contract QuestTerminalKey is
     string public imageIPFSHash;
     string public animationUrlIPFSHash;
     mapping(uint256 => Discount) public discounts;
-    struct Discount {
-        uint16 percentage; //in BIPS
-        uint16 usedCount;
-    }
+
 
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() {

--- a/contracts/QuestTerminalKey.sol
+++ b/contracts/QuestTerminalKey.sol
@@ -11,8 +11,9 @@ import '@openzeppelin/contracts-upgradeable/utils/CountersUpgradeable.sol';
 import {Base64} from 'solady/src/utils/Base64.sol';
 import {LibString} from 'solady/src/utils/LibString.sol';
 import {ReentrancyGuardUpgradeable} from "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol";
-
+import {IQuestTerminalKey} from "./interfaces/IQuestTerminalKey.sol";
 contract QuestTerminalKey is
+    IQuestTerminalKey,
     Initializable,
     ERC721Upgradeable,
     ERC721EnumerableUpgradeable,
@@ -21,9 +22,6 @@ contract QuestTerminalKey is
     IERC2981Upgradeable,
     ReentrancyGuardUpgradeable
 {
-    event RoyaltyFeeSet(uint256 indexed royaltyFee);
-    event MinterAddressSet(address indexed minterAddress);
-    event QuestFactoryAddressSet(address indexed questFactoryAddress);
 
     using CountersUpgradeable for CountersUpgradeable.Counter;
     using LibString for uint256;
@@ -192,7 +190,7 @@ contract QuestTerminalKey is
     function tokenURI(uint256 tokenId_)
         public
         view
-        override(ERC721Upgradeable, ERC721URIStorageUpgradeable)
+        override(ERC721Upgradeable, ERC721URIStorageUpgradeable, IQuestTerminalKey)
         returns (string memory)
     {
         bytes memory dataURI = generateDataURI(tokenId_);
@@ -262,7 +260,7 @@ contract QuestTerminalKey is
     function royaltyInfo(
         uint256 tokenId_,
         uint256 salePrice_
-    ) external view override returns (address receiver, uint256 royaltyAmount) {
+    ) external view override(IERC2981Upgradeable, IQuestTerminalKey) returns (address receiver, uint256 royaltyAmount) {
         require(_exists(tokenId_), 'Nonexistent token');
 
         uint256 royaltyPayment = (salePrice_ * royaltyFee) / 10_000;

--- a/contracts/interfaces/IOwnable.sol
+++ b/contracts/interfaces/IOwnable.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.4;
+pragma solidity ^0.8.18;
 
 interface IOwnable {
     // Events

--- a/contracts/interfaces/IOwnable.sol
+++ b/contracts/interfaces/IOwnable.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.4;
+
+interface IOwnable {
+    // Events
+    event OwnershipTransferred(address indexed oldOwner, address indexed newOwner);
+    event OwnershipHandoverRequested(address indexed pendingOwner);
+    event OwnershipHandoverCanceled(address indexed pendingOwner);
+
+    // Update functions
+    function transferOwnership(address newOwner) external payable;
+    function renounceOwnership() external payable;
+    function requestOwnershipHandover() external payable;
+    function cancelOwnershipHandover() external payable;
+    function completeOwnershipHandover(address pendingOwner) external payable;
+
+    // Read functions
+    function owner() external view returns (address);
+    function ownershipHandoverExpiresAt(address pendingOwner) external view returns (uint256);
+}

--- a/contracts/interfaces/IQuest.sol
+++ b/contracts/interfaces/IQuest.sol
@@ -38,4 +38,5 @@ interface IQuest {
     function rewardToken() external view returns (address);
     function rewardAmountInWei() external view returns (uint256);
     function totalTransferAmount() external view returns (uint256);
+    function questFee() external view returns (uint16);
 }

--- a/contracts/interfaces/IQuest.sol
+++ b/contracts/interfaces/IQuest.sol
@@ -17,6 +17,18 @@ interface IQuest {
     error NotStarted();
     error TotalAmountExceedsBalance();
 
+    function initialize(
+        address rewardTokenAddress_,
+        uint256 endTime_,
+        uint256 startTime_,
+        uint256 totalParticipants_,
+        uint256 rewardAmountInWei_,
+        string memory questId_,
+        uint16 questFee_,
+        address protocolFeeRecipient_,
+        uint40 durationTotal_,
+        address sablierV2LockupLinearAddress_
+    ) external;
     function getRewardAmount() external view returns (uint256);
     function getRewardToken() external view returns (address);
     function queued() external view returns (bool);

--- a/contracts/interfaces/IQuest.sol
+++ b/contracts/interfaces/IQuest.sol
@@ -41,4 +41,5 @@ interface IQuest {
     function questFee() external view returns (uint16);
     function totalParticipants() external view returns (uint256);
     function redeemedTokens() external view returns (uint256);
+    function hasWithdrawn() external view returns (bool);
 }

--- a/contracts/interfaces/IQuest.sol
+++ b/contracts/interfaces/IQuest.sol
@@ -39,4 +39,5 @@ interface IQuest {
     function rewardAmountInWei() external view returns (uint256);
     function totalTransferAmount() external view returns (uint256);
     function questFee() external view returns (uint16);
+    function totalParticipants() external view returns (uint256);
 }

--- a/contracts/interfaces/IQuest.sol
+++ b/contracts/interfaces/IQuest.sol
@@ -40,4 +40,5 @@ interface IQuest {
     function totalTransferAmount() external view returns (uint256);
     function questFee() external view returns (uint16);
     function totalParticipants() external view returns (uint256);
+    function redeemedTokens() external view returns (uint256);
 }

--- a/contracts/interfaces/IQuest.sol
+++ b/contracts/interfaces/IQuest.sol
@@ -25,4 +25,5 @@ interface IQuest {
     function singleClaim(address account) external;
     function rewardToken() external view returns (address);
     function rewardAmountInWei() external view returns (uint256);
+    function totalTransferAmount() external view returns (uint256);
 }

--- a/contracts/interfaces/IQuest1155.sol
+++ b/contracts/interfaces/IQuest1155.sol
@@ -18,6 +18,17 @@ interface IQuest1155 {
     error QuestEnded();
     error AlreadyWithdrawn();
 
+    // Initializer/Contstructor Function
+    function initialize(
+        address rewardTokenAddress_,
+        uint endTime_,
+        uint startTime_,
+        uint totalParticipants_,
+        uint tokenId_,
+        uint questFee_,
+        address protocolFeeRecipient_
+    ) external;
+
     // Read Functions
     function endTime() external view returns (uint256);
     function hasWithdrawn() external view returns (bool);

--- a/contracts/interfaces/IQuest1155.sol
+++ b/contracts/interfaces/IQuest1155.sol
@@ -2,12 +2,37 @@
 pragma solidity ^0.8.18;
 
 interface IQuest1155 {
-    function singleClaim(address account) external;
+    // Events
+    event ClaimedSingle(address indexed account, address rewardAddress, uint amount);
+    event Queued(uint timestamp);
+
+    // Errors
+    error EndTimeInPast();
+    error EndTimeLessThanOrEqualToStartTime();
+    error InsufficientTokenBalance();
+    error InsufficientETHBalance();
+    error NotStarted();
+    error NotEnded();
+    error NotQueued();
+    error NotQuestFactory();
+    error QuestEnded();
+    error AlreadyWithdrawn();
+
+    // Read Functions
+    function endTime() external view returns (uint256);
+    function hasWithdrawn() external view returns (bool);
+
+    function maxProtocolReward() external view returns (uint);
+    function questFee() external view returns (uint256);
     function queued() external view returns (bool);
     function startTime() external view returns (uint256);
-    function endTime() external view returns (uint256);
-    function rewardToken() external view returns (address);
     function tokenId() external view returns (uint256);
-    function questFee() external view returns (uint256);
-    function hasWithdrawn() external view returns (bool);
+    function rewardToken() external view returns (address);
+
+    // Update Functions
+    function pause() external;
+    function queue() external;
+    function singleClaim(address account_) external;
+    function unPause() external;
+    function withdrawRemainingTokens() external;
 }

--- a/contracts/interfaces/IQuest1155Ownable.sol
+++ b/contracts/interfaces/IQuest1155Ownable.sol
@@ -1,0 +1,5 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.18;
+import {IOwnable} from "./IOwnable.sol"; 
+import {IQuest1155} from "./IQuest1155.sol";
+interface IQuest1155Ownable is IQuest1155, IOwnable { }

--- a/contracts/interfaces/IQuestOwnable.sol
+++ b/contracts/interfaces/IQuestOwnable.sol
@@ -1,0 +1,5 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.18;
+import {IOwnable} from "./IOwnable.sol"; 
+import {IQuest} from "./IQuest.sol";
+interface IQuestOwnable is IQuest, IOwnable { }

--- a/contracts/interfaces/IQuestTerminalKey.sol
+++ b/contracts/interfaces/IQuestTerminalKey.sol
@@ -2,6 +2,12 @@
 pragma solidity ^0.8.18;
 
 interface IQuestTerminalKey {
+    // Structs
+    struct Discount {
+        uint16 percentage; //in BIPS
+        uint16 usedCount;
+    }
+    
     // Events
     event RoyaltyFeeSet(uint256 indexed royaltyFee);
     event MinterAddressSet(address indexed minterAddress);
@@ -32,4 +38,5 @@ interface IQuestTerminalKey {
     function getOwnedTokenIds(address owner_) external view returns (uint256[] memory);
     function tokenURI(uint256 tokenId_) external view returns (string memory);
     function royaltyInfo(uint256 tokenId_, uint256 salePrice_) external view returns (address receiver, uint256 royaltyAmount);
+    function discounts(uint256 tokenId_) external view returns (uint16 percentage, uint16 usedCount);
 }

--- a/contracts/interfaces/IQuestTerminalKey.sol
+++ b/contracts/interfaces/IQuestTerminalKey.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.18;
+
+interface IQuestTerminalKey {
+    // Events
+    event RoyaltyFeeSet(uint256 indexed royaltyFee);
+    event MinterAddressSet(address indexed minterAddress);
+    event QuestFactoryAddressSet(address indexed questFactoryAddress);
+    
+    // Update Functions
+    function initialize(
+        address royaltyRecipient_,
+        address minterAddress_,
+        address questFactoryAddress_,
+        uint royaltyFee_,
+        address owner_,
+        string memory imageIPFSHash_,
+        string memory animationUrlIPFSHash_
+    ) external;
+
+    function setImageIPFSHash(string memory imageIPFSHash_) external;
+    function setAnimationUrlIPFSHash(string memory animationUrlIPFSHash_) external;
+    function setRoyaltyRecipient(address royaltyRecipient_) external;
+    function setMinterAddress(address minterAddress_) external;
+    function setQuestFactoryAddress(address questFactoryAddress_) external;
+    function setRoyaltyFee(uint256 royaltyFee_) external;
+    function mint(address to_, uint16 discountPercentage_) external;
+    function bulkMintNoDiscount(address[] memory addresses_) external;
+    function incrementUsedCount(uint tokenId_) external;
+
+    // Read Functions
+    function getOwnedTokenIds(address owner_) external view returns (uint256[] memory);
+    function tokenURI(uint256 tokenId_) external view returns (string memory);
+    function royaltyInfo(uint256 tokenId_, uint256 salePrice_) external view returns (address receiver, uint256 royaltyAmount);
+}

--- a/contracts/interfaces/IQuestTerminalKeyERC721.sol
+++ b/contracts/interfaces/IQuestTerminalKeyERC721.sol
@@ -1,0 +1,5 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.18;
+import {IERC721Upgradeable} from '@openzeppelin/contracts-upgradeable/token/ERC721/IERC721Upgradeable.sol';
+import {IQuestTerminalKey} from "./IQuestTerminalKey.sol";
+interface IQuestTerminalKeyERC721 is IQuestTerminalKey, IERC721Upgradeable { }


### PR DESCRIPTION
This PR sorts out the import statements in two of our highest traffic contracts, `QuestFactory` and `Quest` then incrementally moves each of them away from using direct contract instances, towards using contract interfaces. I also added some interfaces that were missing and cleanup some of the interfaces that I was touching. Not all interfaces have gotten this update yet, and I'll handle the rest of this when I handle #175.

I made a few aggregate interfaces. Alternatively, I could have had the interface inherit from the secondary interface and handle the overrides in the implementing interface (`IQuest` inherits from `IOwnable`) but I like this aggregate approach since it leaves a little more flexibility. If we prefer to collapse all of the functionality into the one main interface over using interface aggregates I'd be happy to make that change.

I also started the process of pulling events, structs, and errors into the interfaces but that work will continue in #175 and #172. For now I only did that in interfaces I was already touching for this PR.


Closes #168 