### PR TITLE
⚡️Global: Replace string errors with custom errors

### DIFF
--- a/contracts/OwnableUpgradeable.sol
+++ b/contracts/OwnableUpgradeable.sol
@@ -21,6 +21,7 @@ import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Ini
  */
 abstract contract OwnableUpgradeable is Initializable, ContextUpgradeable {
     error OnlyOwner();
+    error InvalidNewOwner();
 
     address private _owner;
 
@@ -77,8 +78,7 @@ abstract contract OwnableUpgradeable is Initializable, ContextUpgradeable {
      * Can only be called by the current owner.
      */
     function transferOwnership(address newOwner) public virtual onlyOwner {
-        // solhint-disable-next-line custom-errors, reason-string
-        require(newOwner != address(0), "Ownable: new owner is the zero address");
+        if (newOwner == address(0)) revert InvalidNewOwner();
         _transferOwnership(newOwner);
     }
 

--- a/contracts/OwnableUpgradeable.sol
+++ b/contracts/OwnableUpgradeable.sol
@@ -20,6 +20,8 @@ import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Ini
  * the owner.
  */
 abstract contract OwnableUpgradeable is Initializable, ContextUpgradeable {
+    error OnlyOwner();
+
     address private _owner;
 
     event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
@@ -56,8 +58,7 @@ abstract contract OwnableUpgradeable is Initializable, ContextUpgradeable {
      * @dev Throws if the sender is not the owner.
      */
     function _checkOwner() internal view virtual {
-        // solhint-disable-next-line custom-errors
-        require(owner() == _msgSender(), "Ownable: caller is not the owner");
+        if (owner() != _msgSender()) revert OnlyOwner();
     }
 
     /**

--- a/contracts/Quest.sol
+++ b/contracts/Quest.sol
@@ -105,7 +105,6 @@ contract Quest is ReentrancyGuardUpgradeable, PausableUpgradeable, Ownable, IQue
     }
 
     modifier onlyProtocolFeeRecipientOrOwner() {
-        // solhint-disable-next-line reason-string, custom-errors
         if (msg.sender != protocolFeeRecipient && msg.sender != owner()) revert AuthOwnerRecipient();
         _;
     }
@@ -158,13 +157,9 @@ contract Quest is ReentrancyGuardUpgradeable, PausableUpgradeable, Ownable, IQue
     /// @notice Function that allows either the protocol fee recipient or the owner to withdraw the remaining tokens in the contract
     /// @dev Can only be called after the quest has ended - pays protocol fee and returns remaining tokens to owner
     function withdrawRemainingTokens() external onlyProtocolFeeRecipientOrOwner onlyWithdrawAfterEnd {
-        // solhint-disable-next-line custom-errors
-        require(!hasWithdrawn, "Already withdrawn");
-
+        if (hasWithdrawn) revert AlreadyWithdrawn();
         rewardToken.safeTransfer(protocolFeeRecipient, this.protocolFee());
-
         rewardToken.safeTransfer(owner(), rewardToken.balanceOf(address(this)));
-
         hasWithdrawn = true;
     }
 

--- a/contracts/Quest.sol
+++ b/contracts/Quest.sol
@@ -106,7 +106,7 @@ contract Quest is ReentrancyGuardUpgradeable, PausableUpgradeable, Ownable, IQue
 
     modifier onlyProtocolFeeRecipientOrOwner() {
         // solhint-disable-next-line reason-string, custom-errors
-        require(msg.sender == protocolFeeRecipient || msg.sender == owner(), "Not protocol fee recipient or owner");
+        if (msg.sender != protocolFeeRecipient && msg.sender != owner()) revert AuthOwnerRecipient();
         _;
     }
 

--- a/contracts/Quest.sol
+++ b/contracts/Quest.sol
@@ -187,8 +187,7 @@ contract Quest is ReentrancyGuardUpgradeable, PausableUpgradeable, Ownable, IQue
     /// @dev transfer all coins and tokens that is not the rewardToken to the contract owner.
     /// @param erc20Address_ The address of the ERC20 token to refund
     function refund(address erc20Address_) external onlyOwner {
-        // solhint-disable-next-line custom-errors
-        require(erc20Address_ != rewardToken, "Cannot refund reward token");
+        if (erc20Address_ == rewardToken) revert InvalidRefundToken();
 
         uint256 balance = address(this).balance;
         if (balance > 0) payable(msg.sender).transfer(balance);

--- a/contracts/QuestFactory.sol
+++ b/contracts/QuestFactory.sol
@@ -225,11 +225,7 @@ contract QuestFactory is Initializable, OwnableUpgradeable, AccessControlUpgrade
     }
 
     function doDiscountedFee(uint256 tokenId_) internal returns (uint16) {
-        // solhint-disable-next-line custom-errors, reason-string
-        require(
-            questTerminalKeyContract.ownerOf(tokenId_) == msg.sender,
-            "QuestFactory: caller is not owner of discount token"
-        );
+        if (questTerminalKeyContract.ownerOf(tokenId_) != msg.sender) revert AuthOwnerDiscountToken();
 
         (uint16 discountPercentage,) = questTerminalKeyContract.discounts(tokenId_);
 

--- a/contracts/QuestFactory.sol
+++ b/contracts/QuestFactory.sol
@@ -112,8 +112,7 @@ contract QuestFactory is Initializable, OwnableUpgradeable, AccessControlUpgrade
     /// @dev from https://github.com/transmissions11/solmate/blob/main/src/utils/ReentrancyGuard.sol
     modifier nonReentrant() virtual {
         if (locked == 0) locked = 1;
-        // solhint-disable-next-line custom-errors
-        require(locked == 1, "REENTRANCY");
+        if (locked != 1) revert Reentrancy();
         locked = 2;
         _;
         locked = 1;

--- a/contracts/QuestFactory.sol
+++ b/contracts/QuestFactory.sol
@@ -135,8 +135,7 @@ contract QuestFactory is Initializable, OwnableUpgradeable, AccessControlUpgrade
     }
 
     modifier sufficientMintFee() {
-        // solhint-disable-next-line custom-errors
-        require(msg.value >= mintFee, "Insufficient mint fee");
+        if (msg.value < mintFee) revert InvalidMintFee();
         _;
     }
 

--- a/contracts/QuestTerminalKey.sol
+++ b/contracts/QuestTerminalKey.sol
@@ -29,6 +29,7 @@ contract QuestTerminalKey is
     error ZeroAddress();
     error InvalidDiscountPercentage();
     error NonexistentToken();
+    error OnlyMinter();
 
     event RoyaltyFeeSet(uint256 indexed royaltyFee);
     event MinterAddressSet(address indexed minterAddress);
@@ -81,8 +82,7 @@ contract QuestTerminalKey is
     }
 
     modifier onlyMinter() {
-        // solhint-disable-next-line custom-errors
-        require(msg.sender == minterAddress, "Only minter");
+        if (msg.sender != minterAddress) revert OnlyMinter();
         _;
     }
 

--- a/contracts/QuestTerminalKey.sol
+++ b/contracts/QuestTerminalKey.sol
@@ -28,6 +28,7 @@ contract QuestTerminalKey is
 {
     error ZeroAddress();
     error InvalidDiscountPercentage();
+    error NonexistentToken();
 
     event RoyaltyFeeSet(uint256 indexed royaltyFee);
     event MinterAddressSet(address indexed minterAddress);
@@ -270,8 +271,7 @@ contract QuestTerminalKey is
         uint256 tokenId_,
         uint256 salePrice_
     ) external view override returns (address receiver, uint256 royaltyAmount) {
-        // solhint-disable-next-line custom-errors
-        require(_exists(tokenId_), "Nonexistent token");
+        if (!_exists(tokenId_)) revert NonexistentToken();
 
         uint256 royaltyPayment = (salePrice_ * royaltyFee) / 10_000;
         return (royaltyRecipient, royaltyPayment);

--- a/contracts/QuestTerminalKey.sol
+++ b/contracts/QuestTerminalKey.sol
@@ -26,6 +26,8 @@ contract QuestTerminalKey is
     IERC2981Upgradeable,
     ReentrancyGuardUpgradeable
 {
+    error ZeroAddress();
+
     event RoyaltyFeeSet(uint256 indexed royaltyFee);
     event MinterAddressSet(address indexed minterAddress);
     event QuestFactoryAddressSet(address indexed questFactoryAddress);
@@ -91,8 +93,7 @@ contract QuestTerminalKey is
     /// @dev modifier to check for zero address
     /// @param _address the address to check
     modifier nonZeroAddress(address _address) {
-        // solhint-disable-next-line custom-errors
-        require(_address != address(0), "Zero address");
+        if (_address == address(0)) revert ZeroAddress();
         _;
     }
 

--- a/contracts/QuestTerminalKey.sol
+++ b/contracts/QuestTerminalKey.sol
@@ -30,6 +30,7 @@ contract QuestTerminalKey is
     error InvalidDiscountPercentage();
     error NonexistentToken();
     error OnlyMinter();
+    error OnlyFactory();
 
     event RoyaltyFeeSet(uint256 indexed royaltyFee);
     event MinterAddressSet(address indexed minterAddress);
@@ -87,8 +88,7 @@ contract QuestTerminalKey is
     }
 
     modifier onlyQuestFactory() {
-        // solhint-disable-next-line custom-errors
-        require(msg.sender == questFactoryAddress, "Only quest factory");
+        if (msg.sender != questFactoryAddress) revert OnlyFactory();
         _;
     }
 

--- a/contracts/QuestTerminalKey.sol
+++ b/contracts/QuestTerminalKey.sol
@@ -27,6 +27,7 @@ contract QuestTerminalKey is
     ReentrancyGuardUpgradeable
 {
     error ZeroAddress();
+    error InvalidDiscountPercentage();
 
     event RoyaltyFeeSet(uint256 indexed royaltyFee);
     event MinterAddressSet(address indexed minterAddress);
@@ -144,8 +145,7 @@ contract QuestTerminalKey is
     /// @param to_ the address to mint to
     /// @param discountPercentage_ the discount percentage
     function mint(address to_, uint16 discountPercentage_) external onlyMinter {
-        // solhint-disable-next-line custom-errors
-        require(discountPercentage_ <= 10_000, "Invalid discount percentage");
+        if (discountPercentage_ > 10_000) revert InvalidDiscountPercentage();
 
         mintWithDiscount(to_, discountPercentage_);
     }

--- a/contracts/interfaces/IQuest.sol
+++ b/contracts/interfaces/IQuest.sol
@@ -16,6 +16,7 @@ interface IQuest {
     error NoWithdrawDuringClaim();
     error NotStarted();
     error TotalAmountExceedsBalance();
+    error AuthOwnerRecipient();
 
     function getRewardAmount() external view returns (uint256);
     function getRewardToken() external view returns (address);

--- a/contracts/interfaces/IQuest.sol
+++ b/contracts/interfaces/IQuest.sol
@@ -7,6 +7,7 @@ interface IQuest {
     event JsonSpecCIDSet(string cid);
 
     error AlreadyClaimed();
+    error AlreadyWithdrawn();
     error AmountExceedsBalance();
     error ClaimWindowNotStarted();
     error EndTimeInPast();

--- a/contracts/interfaces/IQuest.sol
+++ b/contracts/interfaces/IQuest.sol
@@ -12,6 +12,7 @@ interface IQuest {
     error ClaimWindowNotStarted();
     error EndTimeInPast();
     error EndTimeLessThanOrEqualToStartTime();
+    error InvalidRefundToken();
     error MustImplementInChild();
     error NotQuestFactory();
     error NoWithdrawDuringClaim();

--- a/contracts/interfaces/IQuestFactory.sol
+++ b/contracts/interfaces/IQuestFactory.sol
@@ -22,6 +22,7 @@ interface IQuestFactory {
     error Deprecated();
     error QuestTypeNotSupported();
     error Reentrancy();
+    error InvalidMintFee();
 
     event QuestCreated(
         address indexed creator,

--- a/contracts/interfaces/IQuestFactory.sol
+++ b/contracts/interfaces/IQuestFactory.sol
@@ -21,6 +21,7 @@ interface IQuestFactory {
     error MsgValueLessThanQuestNFTFee();
     error Deprecated();
     error QuestTypeNotSupported();
+    error Reentrancy();
 
     event QuestCreated(
         address indexed creator,

--- a/contracts/interfaces/IQuestFactory.sol
+++ b/contracts/interfaces/IQuestFactory.sol
@@ -5,6 +5,7 @@ interface IQuestFactory {
     error AddressAlreadyMinted();
     error AddressNotSigned();
     error AddressZeroNotAllowed();
+    error AuthOwnerDiscountToken();
     error Erc20QuestAddressNotSet();
     error InvalidHash();
     error OnlyOwnerCanCreate1155Quest();

--- a/test/Quest.spec.ts
+++ b/test/Quest.spec.ts
@@ -215,8 +215,9 @@ describe('Quest', async () => {
 
   describe('withdrawRemainingTokens()', async () => {
     it('should only allow the owner to withdrawRemainingTokens', async () => {
-      await expect(deployedQuestContract.connect(firstAddress).withdrawRemainingTokens()).to.be.revertedWith(
-        'Not protocol fee recipient or owner'
+      await expect(deployedQuestContract.connect(firstAddress).withdrawRemainingTokens()).to.be.revertedWithCustomError(
+        questContract,
+        'AuthOwnerRecipient'
       )
     })
 

--- a/test/QuestFactory.spec.ts
+++ b/test/QuestFactory.spec.ts
@@ -549,7 +549,7 @@ describe('QuestFactory', () => {
         deployedFactoryContract.connect(questUser).claimRewards(erc20QuestId, messageHash, signature, {
           value: requiredFee - 1,
         })
-      ).to.be.revertedWith('Insufficient mint fee')
+      ).to.be.revertedWithCustomError(questFactoryContract, 'InvalidMintFee')
     })
 
     it('should succeed if the mint fee is equal or greator than required amount, and only recieve the required amount', async function () {

--- a/test/QuestTerminalKey.spec.ts
+++ b/test/QuestTerminalKey.spec.ts
@@ -63,8 +63,9 @@ describe('QuestTerminalKey Contract', async () => {
     })
 
     it('reverts if not called by minter', async () => {
-      await expect(questTerminalKey.connect(firstAddress).mint(firstAddress.address, 1000)).to.be.revertedWith(
-        'Only minter'
+      await expect(questTerminalKey.connect(firstAddress).mint(firstAddress.address, 1000)).to.be.revertedWithCustomError(
+        questTerminalKey,
+        'OnlyMinter'
       )
     })
   })
@@ -81,7 +82,7 @@ describe('QuestTerminalKey Contract', async () => {
     it('reverts if not called by minter', async () => {
       await expect(
         questTerminalKey.connect(firstAddress).bulkMintNoDiscount([firstAddress.address])
-      ).to.be.revertedWith('Only minter')
+      ).to.be.revertedWithCustomError(questTerminalKey, 'OnlyMinter')
     })
   })
 


### PR DESCRIPTION
Pretty straight forward. Switched all the require/strings with custom errors. I put the errors in the interface if there was one and in the contract if there wasn't. I'll migrate them all to the interfaces when I merge down PR #177

In general I think we might be using more nuance in our error messages than needed, I think some more basic errors re-used might be just as good. Something to consider if we start needing to optimize for contract storage, but until then I like the more verbose versions.

Closes #172 