### PR TITLE
remove locked == 0 check

### DIFF
--- a/contracts/QuestFactory.sol
+++ b/contracts/QuestFactory.sol
@@ -121,7 +121,6 @@ contract QuestFactory is Initializable, OwnableUpgradeable, AccessControlUpgrade
     /// @dev ReentrancyGuard modifier from solmate, copied here because it was added after storage layout was finalized on first deploy
     /// @dev from https://github.com/transmissions11/solmate/blob/main/src/utils/ReentrancyGuard.sol
     modifier nonReentrant() virtual {
-        if (locked == 0) locked = 1;
         if (locked != 1) revert Reentrancy();
         locked = 2;
         _;


### PR DESCRIPTION
This is safe as locked is set to 1 on all networks, and any new networks it will be initialized in the initialize function.

DD:

❯ forge inspect QuestFactory storage-layout --pretty
| Name                         | Type                                                         | Slot | Offset | Bytes | Contract                                |
|------------------------------|--------------------------------------------------------------|------|--------|-------|-----------------------------------------|
...
| locked                       | uint256                                                      | 212  | 0      | 32    | contracts/QuestFactory.sol:QuestFactory |

❯ cast storage 0x52629961F71C1C2564C5aa22372CB1b9fa9EBA3E 212 --rpc-url base
0x0000000000000000000000000000000000000000000000000000000000000001

❯ cast storage 0x52629961F71C1C2564C5aa22372CB1b9fa9EBA3E 212 --rpc-url arbitrum
0x0000000000000000000000000000000000000000000000000000000000000001

❯ cast storage 0x52629961F71C1C2564C5aa22372CB1b9fa9EBA3E 212 --rpc-url polygon
0x0000000000000000000000000000000000000000000000000000000000000001

❯ cast storage 0x52629961F71C1C2564C5aa22372CB1b9fa9EBA3E 212 --rpc-url mainnet
0x0000000000000000000000000000000000000000000000000000000000000001

❯ cast storage 0x52629961F71C1C2564C5aa22372CB1b9fa9EBA3E 212 --rpc-url sepolia
0x0000000000000000000000000000000000000000000000000000000000000001

❯ cast storage 0x52629961F71C1C2564C5aa22372CB1b9fa9EBA3E 212 --rpc-url optimism
0x0000000000000000000000000000000000000000000000000000000000000001