### PR TITLE
add chainid and timestamp to quest address seed

### DIFF
--- a/contracts/QuestFactory.sol
+++ b/contracts/QuestFactory.sol
@@ -170,7 +170,7 @@ contract QuestFactory is Initializable, LegacyStorage, OwnableRoles, IQuestFacto
         if (currentQuest.questAddress != address(0)) revert QuestIdUsed();
 
         address payable newQuest =
-            payable(erc1155QuestAddress.cloneDeterministic(keccak256(abi.encodePacked(msg.sender, questId_))));
+            payable(erc1155QuestAddress.cloneDeterministic(keccak256(abi.encodePacked(msg.sender, block.chainid, block.timestamp))));
         currentQuest.questAddress = address(newQuest);
         currentQuest.totalParticipants = totalParticipants_;
         currentQuest.questAddress.safeTransferETH(msg.value);
@@ -609,7 +609,7 @@ contract QuestFactory is Initializable, LegacyStorage, OwnableRoles, IQuestFacto
     /// @param data_ The erc20 quest data struct
     function createERC20QuestInternal(ERC20QuestData memory data_) internal returns (address) {
         Quest storage currentQuest = quests[data_.questId];
-        address newQuest = erc20QuestAddress.cloneDeterministic(keccak256(abi.encodePacked(msg.sender, data_.questId)));
+        address newQuest = erc20QuestAddress.cloneDeterministic(keccak256(abi.encodePacked(msg.sender, block.chainid, block.timestamp)));
 
         currentQuest.questAddress = address(newQuest);
         currentQuest.totalParticipants = data_.totalParticipants;


### PR DESCRIPTION
This will make quest addresses unique, this helps us move forward with using the [quest address as the id](https://github.com/rabbitholegg/quest-protocol/pull/219), and some infra changes in the indexer.

Why not use CREATE over CREATE2 as CREATE will always give a unique address? Good question, because with create there is a small possibility of a reorg attack to create the same quest address after a re-org. This is mostly for chains like Polygon where reorgs happen more frequently than one would expect.