### PR TITLE
Add test to confirm json output, and remove unneeded event

### DIFF
--- a/contracts/Quest.sol
+++ b/contracts/Quest.sol
@@ -148,7 +148,6 @@ contract Quest is ReentrancyGuardUpgradeable, PausableUpgradeable, Ownable, IQue
         uint256 totalRedeemableRewards = rewardAmountInWei;
         _transferRewards(account_, totalRedeemableRewards);
         redeemedTokens = redeemedTokens + 1;
-        emit ClaimedSingle(account_, rewardToken, totalRedeemableRewards);
     }
 
     /// @notice Function to withdraw the remaining tokens in the contract, distributes the protocol fee and returns remaining tokens to owner

--- a/contracts/Quest1155.sol
+++ b/contracts/Quest1155.sol
@@ -136,7 +136,6 @@ contract Quest1155 is ERC1155Holder, ReentrancyGuardUpgradeable, PausableUpgrade
         redeemedTokens = redeemedTokens + 1;
         _transferRewards(account_, 1);
         if (questFee > 0) protocolFeeRecipient.safeTransferETH(questFee);
-        emit ClaimedSingle(account_, rewardToken, 1);
     }
 
     /// @notice Unpauses the Quest

--- a/contracts/interfaces/IQuest.sol
+++ b/contracts/interfaces/IQuest.sol
@@ -2,7 +2,6 @@
 pragma solidity 0.8.19;
 
 interface IQuest {
-    event ClaimedSingle(address indexed account, address rewardAddress, uint256 amount);
     event Queued(uint256 timestamp);
     event JsonSpecCIDSet(string cid);
     event ProtocolFeeDistributed(string questId, address rewardToken, address protocolOwner, uint256 feeAmountToProtocolOwner, address questOwner, uint256 feeAmountToQuestOwner);

--- a/contracts/interfaces/IQuest1155.sol
+++ b/contracts/interfaces/IQuest1155.sol
@@ -3,7 +3,6 @@ pragma solidity 0.8.19;
 
 interface IQuest1155 {
     // Events
-    event ClaimedSingle(address indexed account, address rewardAddress, uint256 amount);
     event Queued(uint256 timestamp);
 
     // Errors

--- a/test/Quest.t.sol
+++ b/test/Quest.t.sol
@@ -161,8 +161,6 @@ contract TestQuest is Test, TestUtils, Errors, Events {
         uint256 startingBalance = SampleERC20(rewardTokenAddress).balanceOf(participant);
         vm.warp(START_TIME);
         vm.prank(questFactoryMock);
-        vm.expectEmit(true, true, false, false, address(quest));
-        emit ClaimedSingle(participant, rewardTokenAddress, REWARD_AMOUNT_IN_WEI);
         quest.singleClaim(participant);
         assertEq(
             SampleERC20(rewardTokenAddress).balanceOf(participant),
@@ -218,8 +216,6 @@ contract TestQuest is Test, TestUtils, Errors, Events {
         // Claim single and check for correct event logging
         vm.warp(startTime);
         vm.prank(questFactoryMock);
-        vm.expectEmit(true, true, false, false, address(quest));
-        emit ClaimedSingle(participant, rewardTokenAddress, rewardAmountInWei);
         quest.singleClaim(participant);
         // Check that the participant received the correct amount of tokens
         assertEq(
@@ -327,7 +323,6 @@ contract TestQuest is Test, TestUtils, Errors, Events {
             address claimer = makeAddr(string.concat("Claimer", i.toString()));
             vm.warp(START_TIME + i);
             vm.prank(questFactoryMock);
-            emit ClaimedSingle(claimer, rewardTokenAddress, rewardAmountInWei);
             quest.singleClaim(claimer);
         }
         QuestFactoryMock(questFactoryMock).setNumberMinted(totalClaims);

--- a/test/Quest1155.t.sol
+++ b/test/Quest1155.t.sol
@@ -171,10 +171,6 @@ contract TestQuest1155 is Test, Errors, Events {
         vm.prank(questFactoryMock);
         quest.queue();
 
-        // emit ClaimedSingle(account_, rewardToken, 1);
-        vm.expectEmit(true, true, false, false, address(quest));
-        emit ClaimedSingle(participant, address(sampleERC1155), TOKEN_ID);
-
         uint256 protocolFeeRecipientOGBalance = protocolFeeRecipient.balance;
         vm.prank(questFactoryMock);
         quest.singleClaim(participant);

--- a/test/QuestFactory.t.sol
+++ b/test/QuestFactory.t.sol
@@ -11,6 +11,7 @@ import {Quest1155} from "contracts/Quest1155.sol";
 import {SablierV2LockupLinearMock as SablierMock} from "./mocks/SablierV2LockupLinearMock.sol";
 import {LibClone} from "solady/utils/LibClone.sol";
 import {LibString} from "solady/utils/LibString.sol";
+import {JSONParserLib} from "solady/utils/JSONParserLib.sol";
 import {Errors} from "./helpers/Errors.sol";
 import {Events} from "./helpers/Events.sol";
 import {TestUtils} from "./helpers/TestUtils.sol";
@@ -19,6 +20,7 @@ contract TestQuestFactory is Test, Errors, Events, TestUtils {
     using LibClone for address;
     using LibString for address;
     using LibString for string;
+    using JSONParserLib for string;
     using LibString for uint256;
 
     QuestFactory questFactory;
@@ -402,11 +404,14 @@ contract TestQuestFactory is Test, Errors, Events, TestUtils {
 
         // assert QuestClaimedData event
         Vm.Log[] memory entries = vm.getRecordedLogs();
-        assertEq(entries.length, 6);
-        assertEq(entries[3].topics[0], keccak256("QuestClaimedData(address,address,string)"));
-        assertEq(entries[3].topics[1], bytes32(uint256(uint160(participant))));
-        assertEq(entries[3].topics[2], bytes32(uint256(uint160(questAddress))));
-        assertEq(abi.decode(entries[3].data, (string)), finalJson);
+        assertEq(entries.length, 5);
+        assertEq(entries[2].topics[0], keccak256("QuestClaimedData(address,address,string)"));
+        assertEq(entries[2].topics[1], bytes32(uint256(uint160(participant))));
+        assertEq(entries[2].topics[2], bytes32(uint256(uint160(questAddress))));
+
+        string memory returnedJson = abi.decode(entries[2].data, (string));
+        assertEq(returnedJson, finalJson);
+        returnedJson.parse(); // This will revert with ParsingFailed() if the json is not valid
     }
 
     function test_claim_with_bytes_no_referrer() public{
@@ -458,11 +463,14 @@ contract TestQuestFactory is Test, Errors, Events, TestUtils {
 
         // assert QuestClaimedData event
         Vm.Log[] memory entries = vm.getRecordedLogs();
-        assertEq(entries.length, 5, "log length");
-        assertEq(entries[3].topics[0], keccak256("QuestClaimedData(address,address,string)"));
-        assertEq(entries[3].topics[1], bytes32(uint256(uint160(participant))));
-        assertEq(entries[3].topics[2], bytes32(uint256(uint160(questAddress))));
-        assertEq(abi.decode(entries[3].data, (string)), finalJson);
+        assertEq(entries.length, 4, "log length");
+        assertEq(entries[2].topics[0], keccak256("QuestClaimedData(address,address,string)"));
+        assertEq(entries[2].topics[1], bytes32(uint256(uint160(participant))));
+        assertEq(entries[2].topics[2], bytes32(uint256(uint160(questAddress))));
+
+        string memory returnedJson = abi.decode(entries[2].data, (string));
+        assertEq(returnedJson, finalJson);
+        returnedJson.parse(); // This will revert with ParsingFailed() if the json is not valid
     }
 
     function test_claim_with_claimRewards_without_referrer() public{

--- a/test/helpers/Events.sol
+++ b/test/helpers/Events.sol
@@ -2,7 +2,6 @@
 pragma solidity 0.8.19;
 
 contract Events {
-    event ClaimedSingle(address indexed account, address rewardAddress, uint256 amount);
     event Queued(uint256 timestamp);
     event JsonSpecCIDSet(string cid);
 


### PR DESCRIPTION
- Removes `ClaimedSingle` event, as it's not used and redundant.
- Adds a test to confirm the JSON string emitted is valid JSON.