### PR TITLE
Add Soulbound20 Contract

### DIFF
--- a/contracts/Soulbound20.sol
+++ b/contracts/Soulbound20.sol
@@ -4,19 +4,20 @@ pragma solidity 0.8.19;
 import {Ownable} from "solady/auth/Ownable.sol";
 import {ERC20} from "solady/tokens/ERC20.sol";
 import {Initializable} from "openzeppelin-contracts-upgradeable/proxy/utils/Initializable.sol";
+import {OwnableRoles} from "solady/auth/OwnableRoles.sol";
 
-contract Soulbound20 is Initializable, Ownable, ERC20 {
-    error OnlyMinter();
+contract Soulbound20 is Initializable, OwnableRoles, ERC20 {
     error TransferNotAllowed();
 
     event MinterAddressSet(address indexed minterAddress);
     event TransferAllowedSet(bool transferAllowed);
 
+    uint256 public constant MINT_ROLE = 1;
+
     /*//////////////////////////////////////////////////////////////
                                 STORAGE
     //////////////////////////////////////////////////////////////*/
     bool public transferAllowed;
-    address public minterAddress;
     string private _name;
     string private _symbol;
     // insert new vars here at the end to keep the storage layout the same
@@ -29,12 +30,10 @@ contract Soulbound20 is Initializable, Ownable, ERC20 {
 
     function initialize(
         address owner_,
-        address minterAddress_,
         string memory name_,
         string memory symbol_
     ) external initializer {
         _initializeOwner(owner_);
-        minterAddress = minterAddress_;
         _name = name_;
         _symbol = symbol_;
     }
@@ -42,9 +41,7 @@ contract Soulbound20 is Initializable, Ownable, ERC20 {
     /// @dev mint tokens, only callable by the allowed minter
     /// @param to_ the address to mint the ticket to
     /// @param amount_ the amount of the ticket to mint
-    function mint(address to_, uint256 amount_) external {
-        if (msg.sender != minterAddress) revert OnlyMinter();
-
+    function mint(address to_, uint256 amount_) external onlyRoles(MINT_ROLE) {
         _mint(to_, amount_);
     }
 
@@ -52,13 +49,6 @@ contract Soulbound20 is Initializable, Ownable, ERC20 {
     /*//////////////////////////////////////////////////////////////
                                   SET
     //////////////////////////////////////////////////////////////*/
-    /// @dev set the minter address, only callable by the owner
-    /// @param minterAddress_ the address of the minter
-    function setMinterAddress(address minterAddress_) external onlyOwner {
-        minterAddress = minterAddress_;
-        emit MinterAddressSet(minterAddress_);
-    }
-
     /// @dev set the transfer allowed bool, only callable by the owner
     /// @param transferAllowed_ the bool to set transferAllowed to
     function setTransferAllowed(bool transferAllowed_) external onlyOwner {

--- a/test/SoulBound20.t.sol
+++ b/test/SoulBound20.t.sol
@@ -3,10 +3,11 @@ pragma solidity ^0.8.19;
 
 import "forge-std/Test.sol";
 import {LibClone} from "solady/utils/LibClone.sol";
-import {Soulbound20, Ownable} from "../contracts/Soulbound20.sol";
+import {Soulbound20, OwnableRoles} from "../contracts/Soulbound20.sol";
 
 contract Soulbound20Test is Test {
     using LibClone for address;
+    error Unauthorized();
 
     Soulbound20 soulbound;
     address owner = makeAddr(("owner"));
@@ -17,7 +18,9 @@ contract Soulbound20Test is Test {
     function setUp() public {
         address soulboundAddress = address(new Soulbound20()).cloneDeterministic(keccak256(abi.encodePacked(msg.sender, "SALT")));
         soulbound = Soulbound20(soulboundAddress);
-        soulbound.initialize(owner, minter, "Soulbound Token", "SBT");
+        soulbound.initialize(owner, "Soulbound Token", "SBT");
+        vm.prank(owner);
+        soulbound.grantRoles(minter, 1);
     }
 
     function test_mint() public {
@@ -28,20 +31,8 @@ contract Soulbound20Test is Test {
     }
 
     function test_mint_revertIf_not_minter() public {
-        vm.expectRevert(Soulbound20.OnlyMinter.selector);
+        vm.expectRevert(Unauthorized.selector);
         soulbound.mint(user1, 100);
-    }
-
-    function test_setMinterAddress() public {
-        vm.prank(owner);
-        soulbound.setMinterAddress(user1);
-        assertEq(soulbound.minterAddress(), user1);
-    }
-
-    function test_setMinterAddress_revertIf_notOwner() public {
-        vm.prank(user1);
-        vm.expectRevert(Ownable.Unauthorized.selector);
-        soulbound.setMinterAddress(user2);
     }
 
     function test_transfer_revertIf_notAllowed() public {


### PR DESCRIPTION
This adds a soulbound ERC20 contract to be used as points. 

Assumptions:
- Many addresses should be able to mint at a time.
- Only the owner can change who these address are that can mint
- Only the owner can enable transfers
- The owner is the QuestFactory (can be transferred)
