### PR TITLE
add soulbound20 additions

### DIFF
--- a/contracts/Quest1155.sol
+++ b/contracts/Quest1155.sol
@@ -33,7 +33,6 @@ contract Quest1155 is ERC1155Holder, ReentrancyGuardUpgradeable, PausableUpgrade
     uint256 public startTime;
     uint256 public totalParticipants;
     uint256 public tokenId;
-    uint256 public questFee;
     string public questId;
 
     /*//////////////////////////////////////////////////////////////
@@ -123,22 +122,6 @@ contract Quest1155 is ERC1155Holder, ReentrancyGuardUpgradeable, PausableUpgrade
     function claimFromFactory(address claimer_, address ref_) external payable whenNotEnded onlyQuestFactory {
         _transferRewards(claimer_, 1);
         if (ref_ != address(0)) ref_.safeTransferETH(_claimFee() / 3);
-    }
-
-    /// @dev transfers rewards to the account, can only be called once per account per quest and only by the quest factory
-    /// @param account_ The account to transfer rewards to
-    function singleClaim(address account_)
-        external
-        virtual
-        nonReentrant
-        whenNotPaused
-        whenNotEnded
-        onlyStarted
-        onlyQueued
-        onlyQuestFactory
-    {
-        _transferRewards(account_, 1);
-        if (questFee > 0) protocolFeeRecipient.safeTransferETH(questFee);
     }
 
     /// @notice Unpauses the Quest

--- a/contracts/QuestFactory.sol
+++ b/contracts/QuestFactory.sol
@@ -139,6 +139,9 @@ contract QuestFactory is Initializable, LegacyStorage, OwnableRoles, IQuestFacto
                                  CREATE
     //////////////////////////////////////////////////////////////*/
 
+    /// @dev Create a soulbound20 contract
+    /// @param name_ The name of the soulbound20
+    /// @param symbol_ The symbol of the soulbound20
    function createSoulbound20(
         string memory name_,
         string memory symbol_
@@ -156,18 +159,6 @@ contract QuestFactory is Initializable, LegacyStorage, OwnableRoles, IQuestFacto
 
         emit Soulbound20Created(msg.sender, soulboundAddress, name_, symbol_);
         return soulboundAddress;
-    }
-
-    function setSoulbound20Verified(address soulbound20Address_) external onlyOwnerOrRoles(SET_SOULBOUND_ADDRESS_STATE_ROLE) {
-        setSoulbound20AddressState(soulbound20Address_, 2);
-    }
-
-    function setSoulbound20Removed(address soulbound20Address_) external onlyOwnerOrRoles(SET_SOULBOUND_ADDRESS_STATE_ROLE) {
-        setSoulbound20AddressState(soulbound20Address_, 3);
-    }
-
-    function setSoulbound20CreateFee(uint256 soulbound20CreateFee_) external onlyOwner {
-        soulbound20CreateFee = soulbound20CreateFee_;
     }
 
     /// @dev Create an erc20 points quest and start it at the same time.
@@ -470,6 +461,25 @@ contract QuestFactory is Initializable, LegacyStorage, OwnableRoles, IQuestFacto
     /*//////////////////////////////////////////////////////////////
                                   SET
     //////////////////////////////////////////////////////////////*/
+
+    /// @dev set a soulbound20 address state to verified
+    /// @param soulbound20Address_ The address of the soulbound20
+    function setSoulbound20Verified(address soulbound20Address_) external onlyOwnerOrRoles(SET_SOULBOUND_ADDRESS_STATE_ROLE) {
+        setSoulbound20AddressState(soulbound20Address_, 2);
+    }
+
+    /// @dev set a soulbound20 address state to removed
+    /// @param soulbound20Address_ The address of the soulbound20
+    function setSoulbound20Removed(address soulbound20Address_) external onlyOwnerOrRoles(SET_SOULBOUND_ADDRESS_STATE_ROLE) {
+        setSoulbound20AddressState(soulbound20Address_, 3);
+    }
+
+
+    /// @dev set the soulbound20 create fee
+    /// @param soulbound20CreateFee_ The value of the soulbound20 create fee
+    function setSoulbound20CreateFee(uint256 soulbound20CreateFee_) external onlyOwner {
+        soulbound20CreateFee = soulbound20CreateFee_;
+    }
 
     /// @dev set the claim signer address
     /// @param claimSignerAddress_ The address of the claim signer

--- a/contracts/Soulbound20.sol
+++ b/contracts/Soulbound20.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity 0.8.19;
 
-import {Ownable} from "solady/auth/Ownable.sol";
 import {ERC20} from "solady/tokens/ERC20.sol";
 import {Initializable} from "openzeppelin-contracts-upgradeable/proxy/utils/Initializable.sol";
 import {OwnableRoles} from "solady/auth/OwnableRoles.sol";
@@ -9,7 +8,6 @@ import {OwnableRoles} from "solady/auth/OwnableRoles.sol";
 contract Soulbound20 is Initializable, OwnableRoles, ERC20 {
     error TransferNotAllowed();
 
-    event MinterAddressSet(address indexed minterAddress);
     event TransferAllowedSet(bool transferAllowed);
 
     uint256 public constant MINT_ROLE = 1;
@@ -68,7 +66,9 @@ contract Soulbound20 is Initializable, OwnableRoles, ERC20 {
         return _symbol;
     }
 
-    /// soulbound
+    /*//////////////////////////////////////////////////////////////
+                            INTERNAL OVERRIDE
+    //////////////////////////////////////////////////////////////*/
     function _beforeTokenTransfer(address from, address to, uint256) internal virtual override {
         if(transferAllowed) return;
 

--- a/contracts/interfaces/IQuest.sol
+++ b/contracts/interfaces/IQuest.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.19;
 
 interface IQuest {
     event Queued(uint256 timestamp);
-    event ProtocolFeeDistributed(string questId, address rewardToken, address protocolOwner, uint256 feeAmountToProtocolOwner, address questOwner, uint256 feeAmountToQuestOwner);
+    event ProtocolRewardsDistributed(string indexed questId, address rewardToken, address claimer, uint256 claimerSplit, address protocol, uint256 protocolSplit, address questOwner, uint256 questOwnerSplit, address referral, uint256 referralSplit);
 
     error AlreadyClaimed();
     error AlreadyWithdrawn();
@@ -23,6 +23,8 @@ interface IQuest {
     error OverMaxAllowedToMint();
     error AddressAlreadyMinted();
     error QuestEnded();
+    error WithdrawNotAvailableForPoints();
+    error InvalidQuestType();
 
     function initialize(
         address rewardTokenAddress_,
@@ -32,14 +34,14 @@ interface IQuest {
         uint256 rewardAmountInWei_,
         string memory questId_,
         uint16 questFee_,
-        address protocolFeeRecipient_
+        address protocolFeeRecipient_,
+        string memory questType_
     ) external;
     function getRewardAmount() external view returns (uint256);
     function getRewardToken() external view returns (address);
     function queued() external view returns (bool);
     function startTime() external view returns (uint256);
     function endTime() external view returns (uint256);
-    function singleClaim(address account) external;
     function rewardToken() external view returns (address);
     function rewardAmountInWei() external view returns (uint256);
     function totalTransferAmount() external view returns (uint256);

--- a/contracts/interfaces/IQuest.sol
+++ b/contracts/interfaces/IQuest.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.19;
 
 interface IQuest {
     event Queued(uint256 timestamp);
-    event ProtocolRewardsDistributed(string indexed questId, address rewardToken, address claimer, uint256 claimerSplit, address protocol, uint256 protocolSplit, address questOwner, uint256 questOwnerSplit, address referral, uint256 referralSplit);
+    event ProtocolFeeDistributed(string questId, address rewardToken, address protocolOwner, uint256 feeAmountToProtocolOwner, address questOwner, uint256 feeAmountToQuestOwner);
 
     error AlreadyClaimed();
     error AlreadyWithdrawn();

--- a/contracts/interfaces/IQuest1155.sol
+++ b/contracts/interfaces/IQuest1155.sol
@@ -54,7 +54,6 @@ interface IQuest1155 {
     function hasWithdrawn() external view returns (bool);
 
     function maxProtocolReward() external view returns (uint256);
-    function questFee() external view returns (uint256);
     function queued() external view returns (bool);
     function startTime() external view returns (uint256);
     function tokenId() external view returns (uint256);
@@ -63,7 +62,6 @@ interface IQuest1155 {
     // Update Functions
     function pause() external;
     function queue() external;
-    function singleClaim(address account_) external;
     function unPause() external;
     function withdrawRemainingTokens() external;
     }

--- a/contracts/interfaces/IQuestFactory.sol
+++ b/contracts/interfaces/IQuestFactory.sol
@@ -25,6 +25,9 @@ interface IQuestFactory {
     error QuestAddressMismatch();
     error ClaimFailed();
     error txOriginMismatch();
+    error InvalidSoulbound20CreateFeeFee();
+    error NotSoulbound20Creator();
+    error Soulbound20Removed();
 
     // Structs
 
@@ -47,6 +50,12 @@ interface IQuestFactory {
         string actionType;
         string questName;
         uint32 txHashChainId;
+    }
+
+    // This struct is used in a mapping - only add new fields to the end
+    struct Soulbound20 {
+        uint256 state;
+        address creator;
     }
 
     struct QuestData {
@@ -159,6 +168,8 @@ interface IQuestFactory {
         uint256 rewardAmountOrTokenId
     );
     event ReferralFeeSet(uint16 percent);
+    event Soulbound20Created(address indexed creator, address indexed soulboundAddress, string name, string symbol);
+    event Soulbound20AddressStateSet(address indexed soulbound20Address, uint256 state);
 
     // Read Functions
     function getAddressMinted(string memory questId_, address address_) external view returns (bool);
@@ -193,7 +204,6 @@ interface IQuestFactory {
     function setErc1155QuestAddress(address erc1155QuestAddress_) external;
     function setErc20QuestAddress(address erc20QuestAddress_) external;
     function setMintFee(uint256 mintFee_) external;
-    function setDefaultMintFeeRecipient(address mintFeeRecipient_) external;
     function setProtocolFeeRecipient(address protocolFeeRecipient_) external;
     function setQuestFee(uint16 questFee_) external;
     function setRewardAllowlistAddress(address rewardAddress_, bool allowed_) external;

--- a/contracts/interfaces/ISoulbound20.sol
+++ b/contracts/interfaces/ISoulbound20.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.19;
+
+interface ISoulbound20 {
+    // Events
+    event TransferAllowedSet(bool transferAllowed);
+
+    // External functions
+    function initialize( address owner_, string calldata name_, string calldata symbol_) external;
+    function mint(address to_, uint256 amount_) external;
+    function setTransferAllowed(bool transferAllowed_) external;
+    function grantRoles(address account_, uint256 roles_) external;
+
+    // External view functions
+    function name() external view returns (string memory);
+    function symbol() external view returns (string memory);
+    function MINT_ROLE() external view returns (uint256);
+}

--- a/script/Quest.s.sol
+++ b/script/Quest.s.sol
@@ -5,6 +5,7 @@ import {Script} from "forge-std/Script.sol";
 import {Quest} from "../contracts/Quest.sol";
 import {Quest1155} from "../contracts/Quest1155.sol";
 import {QuestFactory} from "../contracts/QuestFactory.sol";
+import {Soulbound20} from "../contracts/Soulbound20.sol";
 import {QuestContractConstants as C} from "../contracts/libraries/QuestContractConstants.sol";
 
 // # To deploy and verify Quest.sol run this command below
@@ -30,6 +31,20 @@ contract Quest1155Deploy is Script {
         vm.startBroadcast(deployerPrivateKey);
 
         QuestFactory(C.QUEST_FACTORY_ADDRESS).setErc1155QuestAddress(address(new Quest1155()));
+
+        vm.stopBroadcast();
+    }
+}
+
+// # To deploy and verify Soulbound20.sol run this command below
+// forge script script/Quest.s.sol:Soulbound20Deploy --rpc-url sepolia --broadcast --verify -vvvv
+contract Soulbound20Deploy is Script {
+    function run() external {
+        uint256 deployerPrivateKey = vm.envUint("MAINNET_PRIVATE_KEY");
+
+        vm.startBroadcast(deployerPrivateKey);
+
+        QuestFactory(C.QUEST_FACTORY_ADDRESS).setSoulbound20Address(address(new Soulbound20()));
 
         vm.stopBroadcast();
     }

--- a/script/QuestFactory.s.sol
+++ b/script/QuestFactory.s.sol
@@ -4,6 +4,7 @@ pragma solidity 0.8.19;
 import {Script} from "forge-std/Script.sol";
 import {Quest} from "../contracts/Quest.sol";
 import {Quest1155} from "../contracts/Quest1155.sol";
+import {Soulbound20} from "../contracts/Soulbound20.sol";
 import {QuestFactory} from "../contracts/QuestFactory.sol";
 import {QuestContractConstants as C} from "../contracts/libraries/QuestContractConstants.sol";
 import {ProxyAdmin, ITransparentUpgradeableProxy} from "openzeppelin-contracts/proxy/transparent/ProxyAdmin.sol";
@@ -55,7 +56,8 @@ contract QuestFactoryDeploy is Script {
             address(new Quest()),               // erc20QuestAddress_
             payable(address(new Quest1155())),  // erc1155QuestAddress_
             owner,                              // ownerAddress_
-            500000000000000,                    // nftQuestFee_,
+            address(new Soulbound20()),         // soulbound20Address_
+            500000000000000,                    // soulbound20CreateFee_,
             5000,                               // referralFee_,
             75000000000000                      // mintFee_
         );

--- a/test/Quest1155.t.sol
+++ b/test/Quest1155.t.sol
@@ -159,16 +159,16 @@ contract TestQuest1155 is Test, Errors, Events, TestUtils {
     }
 
     /*//////////////////////////////////////////////////////////////
-                            SINGLECLAIM
+                            claimFromFactory
     //////////////////////////////////////////////////////////////*/
 
-    function test_singleClaim() public {
+    function test_claimFromFactory() public {
         vm.deal(address(quest), LARGE_ETH_AMOUNT);
         vm.prank(questFactoryMock);
         quest.queue();
 
         vm.prank(questFactoryMock);
-        quest.singleClaim(participant);
+        quest.claimFromFactory(participant, address(0));
 
         assertEq(
             SampleERC1155(sampleERC1155).balanceOf(participant, TOKEN_ID),
@@ -177,38 +177,13 @@ contract TestQuest1155 is Test, Errors, Events, TestUtils {
         );
     }
 
-    // todo add fuzz test
-
-    function test_RevertIf_singleClaim_NotQuestFactory() public {
+    function test_RevertIf_claimFromFactory_NotQuestFactory() public {
         vm.deal(address(quest), LARGE_ETH_AMOUNT);
         vm.prank(questFactoryMock);
         quest.queue();
 
         vm.expectRevert(abi.encodeWithSelector(NotQuestFactory.selector));
-        quest.singleClaim(participant);
-    }
-
-    function test_RevertIf_singleClaim_NotStarted() public {
-        vm.deal(address(quest), LARGE_ETH_AMOUNT);
-        vm.prank(questFactoryMock);
-        quest.queue();
-
-        vm.warp(START_TIME - 1);
-        vm.prank(questFactoryMock);
-        vm.expectRevert(abi.encodeWithSelector(NotStarted.selector));
-        quest.singleClaim(participant);
-    }
-
-    function test_RevertIf_singleClaim_whenNotPaused() public {
-        vm.deal(address(quest), LARGE_ETH_AMOUNT);
-        vm.prank(questFactoryMock);
-        quest.queue();
-        vm.startPrank(questFactoryMock);
-        quest.pause();
-        vm.warp(START_TIME);
-        vm.expectRevert("Pausable: paused");
-        quest.singleClaim(participant);
-        vm.stopPrank();
+        quest.claimFromFactory(participant, address(0));
     }
 
     // /*//////////////////////////////////////////////////////////////

--- a/test/SoulBound20.t.sol
+++ b/test/SoulBound20.t.sol
@@ -23,6 +23,12 @@ contract Soulbound20Test is Test {
         soulbound.grantRoles(minter, 1);
     }
 
+    function test_initialize() public {
+        assertEq(soulbound.owner(), owner);
+        assertEq(soulbound.name(), "Soulbound Token");
+        assertEq(soulbound.symbol(), "SBT");
+    }
+
     function test_mint() public {
         vm.prank(minter);
         soulbound.mint(user1, 100);

--- a/test/helpers/TestUtils.sol
+++ b/test/helpers/TestUtils.sol
@@ -31,4 +31,19 @@ contract TestUtils is Test {
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(privateKey, digest);
         return abi.encodePacked(r, s, v);
     }
+
+    function signHashReturnRS(bytes32 msgHash, uint256 privateKey)
+        internal
+        pure
+        returns (
+            bytes32,
+            bytes32
+        )
+    {
+        bytes32 digest = ECDSA.toEthSignedMessageHash(msgHash);
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(privateKey, digest);
+        if (v != 27) s = s | bytes32(uint256(1) << 255);
+
+        return (r, s);
+    }
 }


### PR DESCRIPTION
This is extracted from https://github.com/rabbitholegg/quest-protocol/pull/247

Additions:
- Adds functions to create and interact with a soulbound erc20 points contract: `createSoulbound20`, `setsoulbound20Verified`, `setSoulbound20Removed`, `setSoulbound20CreateFee`
- Adds function to create a erc20Points Quest: `createERC20PointsQuest`

Cleanups:
- removes quest.`singleClaim` as this function is not called anymore.
- removes `claim1155RewardsRef` and `claimRewardsRef` as they are not called anymore.
- removes `nftQuestFee` from questFactory as it's not used

Deploy plan:
This is okay to deploy now because `soulbound20Address` is not set, so any tx trying to create a soulbound20 quest will revert. This has no changes to the claim flow, it's only additions so it's backwards compatible. 