### PR TITLE
feat(quests): implement cancel operation for quests [BOOST-3960]

### DIFF
--- a/contracts/Quest.sol
+++ b/contracts/Quest.sol
@@ -121,16 +121,12 @@ contract Quest is ReentrancyGuardUpgradeable, PausableUpgradeable, Ownable, IQue
     /*//////////////////////////////////////////////////////////////
                             EXTERNAL UPDATE
     //////////////////////////////////////////////////////////////*/
-    /// @notice Pauses the Quest
-    /// @dev Only the owner of the Quest can call this function. Also requires that the Quest has started (not by date, but by calling the start function)
-    function pause() external onlyOwner {
-        _pause();
-    }
 
-    /// @notice Unpauses the Quest
-    /// @dev Only the owner of the Quest can call this function. Also requires that the Quest has started (not by date, but by calling the start function)
-    function unPause() external onlyOwner {
-        _unpause();
+    /// @notice Cancels the Quest by setting the end time to 15 minutes from the current time and pausing the Quest. If the Quest has not yet started, it will end immediately.
+    /// @dev Only the owner of the Quest can call this function.
+    function cancel() external onlyOwner whenNotPaused whenNotEnded {
+        _pause();
+        endTime = startTime > block.timestamp ? block.timestamp : block.timestamp + 15 minutes;
     }
 
     /// @dev transfers rewards to the account, can only be called once per account per quest and only by the quest factory

--- a/contracts/Quest1155.sol
+++ b/contracts/Quest1155.sol
@@ -105,10 +105,12 @@ contract Quest1155 is ERC1155Holder, ReentrancyGuardUpgradeable, PausableUpgrade
     /*//////////////////////////////////////////////////////////////
                             EXTERNAL UPDATE
     //////////////////////////////////////////////////////////////*/
-    /// @notice Pauses the Quest
-    /// @dev Only the owner of the Quest can call this function. Also requires that the Quest has started (not by date, but by calling the start function)
-    function pause() external onlyOwner onlyStarted {
+
+    /// @notice Cancels the Quest by setting the end time to 15 minutes from the current time and pausing the Quest. If the Quest has not yet started, it will end immediately.
+    /// @dev Only the owner of the Quest can call this function.
+    function cancel() external onlyOwner whenNotPaused whenNotEnded {
         _pause();
+        endTime = startTime > block.timestamp ? block.timestamp : block.timestamp + 15 minutes;
     }
 
     /// @notice Queues the quest by marking it ready to start at the contract level. Marking a quest as queued does not mean that it is live. It also requires that the start time has passed
@@ -140,12 +142,6 @@ contract Quest1155 is ERC1155Holder, ReentrancyGuardUpgradeable, PausableUpgrade
     {
         _transferRewards(account_, 1);
         if (questFee > 0) protocolFeeRecipient.safeTransferETH(questFee);
-    }
-
-    /// @notice Unpauses the Quest
-    /// @dev Only the owner of the Quest can call this function. Also requires that the Quest has started (not by date, but by calling the start function)
-    function unPause() external onlyOwner onlyStarted {
-        _unpause();
     }
 
     /// @dev Function that transfers all 1155 tokens in the contract to the owner (creator), and eth to the protocol fee recipient and the owner

--- a/contracts/interfaces/IQuest.sol
+++ b/contracts/interfaces/IQuest.sol
@@ -44,6 +44,7 @@ interface IQuest {
     function startTime() external view returns (uint256);
     function endTime() external view returns (uint256);
     function singleClaim(address account) external;
+    function cancel() external;
     function rewardToken() external view returns (address);
     function rewardAmountInWei() external view returns (uint256);
     function totalTransferAmount() external view returns (uint256);

--- a/contracts/interfaces/IQuest1155.sol
+++ b/contracts/interfaces/IQuest1155.sol
@@ -61,9 +61,8 @@ interface IQuest1155 {
     function rewardToken() external view returns (address);
 
     // Update Functions
-    function pause() external;
+    function cancel() external;
     function queue() external;
     function singleClaim(address account_) external;
-    function unPause() external;
     function withdrawRemainingTokens() external;
     }

--- a/test/Quest.t.sol
+++ b/test/Quest.t.sol
@@ -139,33 +139,26 @@ contract TestQuest is Test, TestUtils, Errors, Events {
     }
 
     /*//////////////////////////////////////////////////////////////
-                                PAUSE
+                                CANCEL
     //////////////////////////////////////////////////////////////*/
-    function test_pause() public {
+    function test_cancel() public {
         vm.prank(questFactoryMock);
-        quest.pause();
+        quest.cancel();
         assertTrue(quest.paused(), "paused should be true");
+        assertEq(quest.endTime(), block.timestamp, "endTime should be now (quest not started)");
     }
 
-    function test_RevertIf_pause_Unauthorized() public {
+    function test_cancel_afterStarted() public {
+        vm.warp(START_TIME);
+        vm.prank(questFactoryMock);
+        quest.cancel();
+        assertTrue(quest.paused(), "paused should be true");
+        assertEq(quest.endTime(), block.timestamp + 15 minutes, "endTime should be 15 minutes from now");
+    }
+
+    function test_RevertIf_cancel_Unauthorized() public {
         vm.expectRevert(abi.encodeWithSelector(Unauthorized.selector));
-        quest.pause();
-    }
-
-    /*//////////////////////////////////////////////////////////////
-                              UNPAUSE
-    //////////////////////////////////////////////////////////////*/
-    function test_unpause() public {
-        vm.startPrank(questFactoryMock);
-        quest.pause();
-        quest.unPause();
-        assertFalse(quest.paused(), "paused should be false");
-        vm.stopPrank();
-    }
-
-    function test_RevertIf_unpause_Unauthorized() public {
-        vm.expectRevert(abi.encodeWithSelector(Unauthorized.selector));
-        quest.unPause();
+        quest.cancel();
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -251,15 +244,6 @@ contract TestQuest is Test, TestUtils, Errors, Events {
         vm.prank(questFactoryMock);
         vm.expectRevert(abi.encodeWithSelector(ClaimWindowNotStarted.selector));
         quest.singleClaim(participant);
-    }
-
-    function test_RevertIf_singleClaim_whenNotPaused() public {
-        vm.startPrank(questFactoryMock);
-        quest.pause();
-        vm.warp(START_TIME);
-        vm.expectRevert("Pausable: paused");
-        quest.singleClaim(participant);
-        vm.stopPrank();
     }
 
     /*//////////////////////////////////////////////////////////////

--- a/test/Quest1155.t.sol
+++ b/test/Quest1155.t.sol
@@ -109,31 +109,22 @@ contract TestQuest1155 is Test, Errors, Events, TestUtils {
     /*//////////////////////////////////////////////////////////////
                                 PAUSE
     //////////////////////////////////////////////////////////////*/
-    function test_pause() public {
+    function test_cancel() public {
         vm.prank(questFactoryMock);
-        quest.pause();
+        quest.cancel();
         assertTrue(quest.paused(), "paused should be true");
+        assertEq(quest.endTime(), block.timestamp + 15 minutes, "endTime should be 15 minutes from now");
     }
 
-    function test_RevertIf_pause_Unauthorized() public {
+    function test_cancel_notStarted() public {
+        vm.warp(START_TIME - 1);
         vm.expectRevert(abi.encodeWithSelector(Unauthorized.selector));
-        quest.pause();
+        quest.cancel();
     }
 
-    /*//////////////////////////////////////////////////////////////
-                              UNPAUSE
-    //////////////////////////////////////////////////////////////*/
-    function test_unpause() public {
-        vm.startPrank(questFactoryMock);
-        quest.pause();
-        quest.unPause();
-        assertFalse(quest.paused(), "paused should be false");
-        vm.stopPrank();
-    }
-
-    function test_RevertIf_unpause_Unauthorized() public {
+    function test_RevertIf_cancel_Unauthorized() public {
         vm.expectRevert(abi.encodeWithSelector(Unauthorized.selector));
-        quest.unPause();
+        quest.cancel();
     }
 
     // /*//////////////////////////////////////////////////////////////
@@ -197,18 +188,6 @@ contract TestQuest1155 is Test, Errors, Events, TestUtils {
         vm.prank(questFactoryMock);
         vm.expectRevert(abi.encodeWithSelector(NotStarted.selector));
         quest.singleClaim(participant);
-    }
-
-    function test_RevertIf_singleClaim_whenNotPaused() public {
-        vm.deal(address(quest), LARGE_ETH_AMOUNT);
-        vm.prank(questFactoryMock);
-        quest.queue();
-        vm.startPrank(questFactoryMock);
-        quest.pause();
-        vm.warp(START_TIME);
-        vm.expectRevert("Pausable: paused");
-        quest.singleClaim(participant);
-        vm.stopPrank();
     }
 
     // /*//////////////////////////////////////////////////////////////


### PR DESCRIPTION
This adds the ability to `cancel` a Quest at any point before the quest's natural end time. 

In order to facilitate cancellation without introducing new complexity, I chose to reuse the existing `pause` functionality (which, incidentally, wasn't actually being used anywhere). When the quest owner calls `cancel`, the quest is transitioned into `paused` state, which has the effect of preventing any future changes to the end time as the cancel function is gated by the `whenNotPaused` modifier. If the quest has not yet started (i.e. `startTime > block.timestamp`), the quest is cancelled effective immediately. If it has already started, the `endTime` is changed to be the current block timestamp plus 15 minutes to allow for any in-flight actions to resolve. The time delay was added to address the potential for malicious quest creators to abuse cancellations to deprive unsuspecting users of earned incentives.