### PR TITLE
feat: add claimCompressedRefBatch function

### DIFF
--- a/contracts/QuestFactory.sol
+++ b/contracts/QuestFactory.sol
@@ -405,7 +405,6 @@ contract QuestFactory is Initializable, LegacyStorage, OwnableRoles, IQuestFacto
             }
         }
 
-        // Refund any excess ETH
         uint256 excess = msg.value - totalFees;
         if (excess > 0) {
             payable(msg.sender).transfer(excess);

--- a/contracts/interfaces/IQuestFactory.sol
+++ b/contracts/interfaces/IQuestFactory.sol
@@ -77,6 +77,13 @@ interface IQuestFactory {
         string extraData;
     }
 
+    /// @dev struct to allow for an array of claims in batch claim functions
+    struct BatchClaimData {
+        bytes compressedData;
+        address claimer;
+        uint256 fee;
+    }
+
     struct ERC20QuestData {
         uint32 txHashChainId;
         address rewardTokenAddress;
@@ -178,6 +185,9 @@ interface IQuestFactory {
         uint256 rewardAmountOrTokenId
     );
     event ReferralFeeSet(uint16 percent);
+
+    /// @dev event to track failed claims in batch claim functions
+    event BatchClaimFailed(address indexed claimer, bytes compressedData, bytes reason);
 
     // Read Functions
     function getAddressMinted(string memory questId_, address address_) external view returns (bool);


### PR DESCRIPTION
This PR adds a batch version of `claimCompresedRef` to allow for multiple claims on behalf of multiple claimers at once.

Individual claim failures do not cause the transaction to revert but do emit a new `BatchClaimFailed` event.

This is to support batch claims for Drakula ([linear ticket](https://linear.app/rh-app/issue/BOOST-4228/add-batch-version-of-claimcompressedref-to-boost-contracts)).