### PR TITLE
[BOOST-4672] implement flexible fee structures for `QuestBudget`

### DIFF
--- a/contracts/QuestBudget.sol
+++ b/contracts/QuestBudget.sol
@@ -55,7 +55,7 @@ contract QuestBudget is Budget, IERC1155Receiver, ReentrancyGuard {
     /// @dev Emitted when the management fee is set or updated
     event ManagementFeeSet(uint256 newFee);
 
-    /// @dev Emitted when a management fee is paid
+    /// @dev Emitted when management fee is paid
     event ManagementFeePaid(string indexed questId, address indexed manager, uint256 amount);
 
     /// @notice A modifier that allows only authorized addresses to call the function

--- a/contracts/QuestBudget.sol
+++ b/contracts/QuestBudget.sol
@@ -40,6 +40,15 @@ contract QuestBudget is Budget, IERC1155Receiver, ReentrancyGuard {
     /// @dev The mapping of authorized addresses
     mapping(address => bool) private _isAuthorized;
 
+    /// @dev The management fee percentage (in basis points, i.e., 100 = 1%)
+    uint256 public managementFee;
+
+    /// @dev Mapping of quest IDs to their respective managers' addresses
+    mapping(string => address) public questManagers;
+
+    /// @dev Total amount of funds reserved for management fees
+    uint256 public reservedFunds;
+
     /// @notice A modifier that allows only authorized addresses to call the function
     modifier onlyAuthorized() {
         if (!isAuthorized(msg.sender)) revert Unauthorized();

--- a/contracts/QuestBudget.sol
+++ b/contracts/QuestBudget.sol
@@ -232,8 +232,8 @@ contract QuestBudget is Budget, IERC1155Receiver, ReentrancyGuard {
     }
 
     /// @notice Allows the quest manager to claim the management fee for a completed quest
-/// @dev This function can only be called by the authorized quest manager after the quest rewards have been withdrawn
-/// @param questId_ The unique identifier of the quest for which the management fee is being claimed
+    /// @dev This function can only be called by the authorized quest manager after the quest rewards have been withdrawn
+    /// @param questId_ The unique identifier of the quest for which the management fee is being claimed
     function payManagementFee(string memory questId_) public onlyAuthorized {
         // Retrieve the quest data by calling the questData function and decoding the result
         IQuestFactory.QuestData memory quest = IQuestFactory(questFactory).questData(questId_);

--- a/contracts/QuestBudget.sol
+++ b/contracts/QuestBudget.sol
@@ -50,6 +50,9 @@ contract QuestBudget is Budget, IERC1155Receiver, ReentrancyGuard {
     /// @dev Total amount of funds reserved for management fees
     uint256 public reservedFunds;
 
+    /// @dev Emitted when the management fee is set or updated
+    event ManagementFeeSet(uint256 newFee);
+
     /// @notice A modifier that allows only authorized addresses to call the function
     modifier onlyAuthorized() {
         if (!isAuthorized(msg.sender)) revert Unauthorized();
@@ -196,6 +199,15 @@ contract QuestBudget is Budget, IERC1155Receiver, ReentrancyGuard {
     /// @param questId_ The uuid of the quest
     function cancelQuest(string calldata questId_) public virtual onlyOwner() {
         IQuestFactory(questFactory).cancelQuest(questId_);
+    }
+
+    /// @notice Sets the management fee percentage
+    /// @dev Only the owner can call this function. The fee is in basis points (100 = 1%)
+    /// @param fee_ The new management fee percentage in basis points
+    function setManagementFee(uint256 fee_) external onlyOwner {
+        require(fee_ <= 10000, "Fee cannot exceed 100%");
+        managementFee = fee_;
+        emit ManagementFeeSet(fee_);
     }
  
     /// @inheritdoc Budget

--- a/contracts/QuestBudget.sol
+++ b/contracts/QuestBudget.sol
@@ -295,10 +295,11 @@ contract QuestBudget is Budget, IERC1155Receiver, ReentrancyGuard {
     /// @notice Get the amount of assets available for distribution from the budget
     /// @param asset_ The address of the asset (or the zero address for native assets)
     /// @return The amount of assets available
-    /// @dev This is simply the current balance held by the budget
+    /// @dev This returns the current balance held by the budget minus reserved funds
     /// @dev If the zero address is passed, this function will return the native balance
     function available(address asset_) public view virtual override returns (uint256) {
-        return asset_ == address(0) ? address(this).balance : asset_.balanceOf(address(this));
+        uint256 totalBalance = asset_ == address(0) ? address(this).balance : IERC20(asset_).balanceOf(address(this));
+        return totalBalance > reservedFunds ? totalBalance - reservedFunds : 0;
     }
 
     /// @notice Get the amount of ERC1155 assets available for distribution from the budget

--- a/contracts/QuestBudget.sol
+++ b/contracts/QuestBudget.sol
@@ -6,6 +6,7 @@ import {IQuestFactory} from "contracts/interfaces/IQuestFactory.sol";
 import {IERC1155Receiver} from "openzeppelin-contracts/token/ERC1155/IERC1155Receiver.sol";
 import {IERC1155} from "openzeppelin-contracts/token/ERC1155/IERC1155.sol";
 import {IERC165} from "openzeppelin-contracts/utils/introspection/IERC165.sol";
+import {IERC20} from "openzeppelin-contracts/token/ERC20/IERC20.sol";
 
 import {SafeTransferLib} from "solady/utils/SafeTransferLib.sol";
 import {ReentrancyGuard} from "solady/utils/ReentrancyGuard.sol";

--- a/test/QuestBudget.t.sol
+++ b/test/QuestBudget.t.sol
@@ -545,7 +545,7 @@ contract QuestBudgetTest is Test, TestUtils, IERC1155Receiver {
     function test_cancel() public {
         // Create quest with standard parameters (60 participants, 1 ETH reward per participant)
         QuestSetupData memory data = setupQuestData();
-        address questAddress = createQuest(data, questBudget.owner());
+        address questAddress = _createQuestWithMockData(data, questBudget.owner());
 
         // Ensure the returned quest address is not the zero address
         assertTrue(questAddress != address(0));
@@ -1104,7 +1104,7 @@ contract QuestBudgetTest is Test, TestUtils, IERC1155Receiver {
 
         // Simulate that the quest has already withdrawn
         data.hasWithdrawn = true;
-        createQuest(data, questBudget.owner());
+        _createQuestWithMockData(data, questBudget.owner());
 
         // Get balance after the quest has withdrawn
         uint256 initialBalance = mockERC20.balanceOf(address(this));
@@ -1131,7 +1131,7 @@ contract QuestBudgetTest is Test, TestUtils, IERC1155Receiver {
 
         // Create quest with standard parameters (60 participants, 1 ETH reward per participant)
         QuestSetupData memory data = setupQuestData();
-        createQuest(data, questBudget.owner());
+        _createQuestWithMockData(data, questBudget.owner());
 
         vm.expectRevert("Management fee cannot be claimed until the quest rewards are withdrawn");
         questBudget.payManagementFee(data.questId);
@@ -1152,7 +1152,7 @@ contract QuestBudgetTest is Test, TestUtils, IERC1155Receiver {
 
         // Create quest with standard parameters (60 participants, 1 ETH reward per participant)
         QuestSetupData memory data = setupQuestData();
-        createQuest(data, questCreator);
+        _createQuestWithMockData(data, questCreator);
 
         // Attempt to call payManagementFee as budget owner (not quest creator)
         vm.prank(questBudget.owner());
@@ -1170,7 +1170,7 @@ contract QuestBudgetTest is Test, TestUtils, IERC1155Receiver {
 
         // Simulate that the quest has already withdrawn
         data.hasWithdrawn = true;
-        createQuest(data, questBudget.owner());
+        _createQuestWithMockData(data, questBudget.owner());
 
         // Transfer 1 wei out of the budget
         vm.prank(address(questBudget));
@@ -1197,7 +1197,7 @@ contract QuestBudgetTest is Test, TestUtils, IERC1155Receiver {
         data.numberMinted = 10;
 
         // Create quest
-        createQuest(data, questBudget.owner());
+        _createQuestWithMockData(data, questBudget.owner());
 
         // Calculate expected fee
         uint256 expectedFeeToPay = (data.numberMinted * data.rewardAmount * managementFeePercentage) / 10_000;
@@ -1226,6 +1226,9 @@ contract QuestBudgetTest is Test, TestUtils, IERC1155Receiver {
     // Test Helper Functions //
     ///////////////////////////
 
+    /// @notice Sets up a default QuestSetupData struct with common test parameters
+    /// @dev This function provides a baseline set of quest data that can be easily modified for different test scenarios
+    /// @return A QuestSetupData struct populated with default values for testing purposes
     function setupQuestData() internal view returns (QuestSetupData memory) {
         return QuestSetupData({
             txHashChainId: 1,
@@ -1244,7 +1247,12 @@ contract QuestBudgetTest is Test, TestUtils, IERC1155Receiver {
         });
     }
 
-    function createQuest(QuestSetupData memory data, address questCreator) internal returns (address questAddress) {
+    /// @notice Creates a quest with mock data for testing purposes
+    /// @dev This function simulates the entire quest creation process, including token allocation and mocking quest data
+    /// @param data The struct containing all necessary quest setup data
+    /// @param questCreator The address that will be set as the quest creator
+    /// @return questAddress The address of the newly created quest contract
+    function _createQuestWithMockData(QuestSetupData memory data, address questCreator) internal returns (address questAddress) {
         uint256 maxTotalRewards = data.totalParticipants * data.rewardAmount;
         uint256 questFee = uint256(mockQuestFactory.questFee());
         uint256 referralRewardFee = uint256(mockQuestFactory.referralRewardFee());

--- a/test/QuestBudget.t.sol
+++ b/test/QuestBudget.t.sol
@@ -1174,7 +1174,7 @@ contract QuestBudgetTest is Test, TestUtils, IERC1155Receiver {
 
         uint256 finalBalance = mockERC20.balanceOf(address(this));
 
-        assertEq(finalBalance - initialBalance, 0.5 ether, "Incorrect management fee paid");
+        assertEq(finalBalance - initialBalance, maxManagementFee, "Incorrect management fee paid");
     }
 
     function testPayManagementFee_NotWithdrawn() public {

--- a/test/QuestBudget.t.sol
+++ b/test/QuestBudget.t.sol
@@ -954,6 +954,38 @@ contract QuestBudgetTest is Test, TestUtils, IERC1155Receiver {
         assertEq(questBudget.available(address(0)), 1 ether);
     }
 
+    //////////////////////////////////
+    // QuestBudget.setManagementFee //
+    //////////////////////////////////
+
+    function testSetManagementFee() public {
+        // Simulate a transaction from the owner of the questBudget contract
+        vm.prank(questBudget.owner());
+
+        // Call the setManagementFee function with a value of 5%
+        questBudget.setManagementFee(500);
+
+        // Assert that the managementFee has been correctly set to 5%
+        assertEq(questBudget.managementFee(), 500);
+    }
+
+    function testSetManagementFee_ExceedsMax() public {
+        // Simulate a transaction from the owner of the questBudget contract
+        vm.prank(questBudget.owner());
+        
+        // Set an initial valid management fee (5%)
+        questBudget.setManagementFee(500);
+        
+        // Expect the next transaction to revert with the specified error message
+        vm.expectRevert("Fee cannot exceed 100%");
+        
+        // Attempt to set a management fee that exceeds 100%
+        questBudget.setManagementFee(10001);
+        
+        // Assert that the management fee remains unchanged at 5%
+        assertEq(questBudget.managementFee(), 500);
+    }
+
     ///////////////////////////
     // Test Helper Functions //
     ///////////////////////////

--- a/test/QuestBudget.t.sol
+++ b/test/QuestBudget.t.sol
@@ -398,6 +398,7 @@ contract QuestBudgetTest is Test, TestUtils, IERC1155Receiver {
         uint256 maxReferralReward = (maxTotalRewards * referralRewardFee) / 10_000;
         uint256 approvalAmount = maxTotalRewards + maxProtocolReward + maxReferralReward;
         mockERC20.mint(address(this), approvalAmount);
+
         // Ensure the budget has enough tokens for the reward
         mockERC20.approve(address(questBudget), approvalAmount);
         questBudget.allocate(
@@ -431,16 +432,28 @@ contract QuestBudgetTest is Test, TestUtils, IERC1155Receiver {
         vm.prank(questBudget.owner());
         questBudget.setManagementFee(500); // 5%
 
-        // Calculate the amounts needed for the quest
-        uint256 totalParticipants = 10;
-        uint256 rewardAmount = 1 ether;
-        uint256 maxTotalRewards = totalParticipants * rewardAmount;
+        // Define the parameters for the new quest
+        uint32 txHashChainId_ = 1;
+        address rewardTokenAddress_ = address(mockERC20);
+        uint256 endTime_ = block.timestamp + 1 days;
+        uint256 startTime_ = block.timestamp;
+        uint256 totalParticipants_ = 10;
+        uint256 rewardAmount_ = 1 ether;
+        string memory questId_ = "testQuest";
+        string memory actionType_ = "testAction";
+        string memory questName_ = "Test Quest";
+        string memory projectName_ = "Test Project";
+        uint256 referralRewardFee_ = 250;
+        
+        uint256 maxTotalRewards = totalParticipants_ * rewardAmount_;
         uint256 questFee = uint256(mockQuestFactory.questFee());
-        uint256 referralRewardFee = 250; // 2.5%
+        uint256 referralRewardFee = uint256(mockQuestFactory.referralRewardFee());
         uint256 maxProtocolReward = (maxTotalRewards * questFee) / 10_000;
         uint256 maxReferralReward = (maxTotalRewards * referralRewardFee) / 10_000;
-        uint256 maxManagementFee = (maxTotalRewards * questBudget.managementFee()) / 10_000; // 5% management fee
         uint256 questFactoryApprovalAmount = maxTotalRewards + maxProtocolReward + maxReferralReward;
+
+        // Calculate the amounts needed for the quest
+        uint256 maxManagementFee = (maxTotalRewards * questBudget.managementFee()) / 10_000;
         uint256 totalAllocationRequired = questFactoryApprovalAmount + maxManagementFee;
 
         // Approve questBudget to spend tokens
@@ -454,17 +467,17 @@ contract QuestBudgetTest is Test, TestUtils, IERC1155Receiver {
         // Create quest
         string memory questId = "testQuest";
         address questAddress = questBudget.createERC20Quest(
-            1, // txHashChainId
-            address(mockERC20), // rewardTokenAddress
-            block.timestamp + 1 days, // endTime
-            block.timestamp, // startTime
-            totalParticipants, // totalParticipants
-            rewardAmount, // rewardAmount
-            questId, // questId
-            "testAction", // actionType
-            "Test Quest", // questName
-            "Test Project", // projectName
-            referralRewardFee // referralRewardFee
+            txHashChainId_,
+            rewardTokenAddress_,
+            endTime_,
+            startTime_,
+            totalParticipants_,
+            rewardAmount_,
+            questId_,
+            actionType_,
+            questName_,
+            projectName_,
+            referralRewardFee_
         );
 
         // Ensure the returned quest address is not the zero address
@@ -490,17 +503,28 @@ contract QuestBudgetTest is Test, TestUtils, IERC1155Receiver {
         // Set management fee
         vm.prank(questBudget.owner());
         questBudget.setManagementFee(500); // 5%
-
-        // Calculate the amounts needed for the quest
-        uint256 totalParticipants = 10;
-        uint256 rewardAmount = 1 ether;
-        uint256 maxTotalRewards = totalParticipants * rewardAmount;
+    
+        // Define the parameters for the new quest
+        uint32 txHashChainId_ = 1;
+        address rewardTokenAddress_ = address(mockERC20);
+        uint256 endTime_ = block.timestamp + 1 days;
+        uint256 startTime_ = block.timestamp;
+        uint256 totalParticipants_ = 10;
+        uint256 rewardAmount_ = 1 ether;
+        string memory questId_ = "testQuest";
+        string memory actionType_ = "testAction";
+        string memory questName_ = "Test Quest";
+        string memory projectName_ = "Test Project";
+        uint256 referralRewardFee_ = 250;
+        
+        uint256 maxTotalRewards = totalParticipants_ * rewardAmount_;
         uint256 questFee = uint256(mockQuestFactory.questFee());
-        uint256 referralRewardFee = 250; // 2.5%
+        uint256 referralRewardFee = uint256(mockQuestFactory.referralRewardFee());
         uint256 maxProtocolReward = (maxTotalRewards * questFee) / 10_000;
         uint256 maxReferralReward = (maxTotalRewards * referralRewardFee) / 10_000;
-        uint256 maxManagementFee = (maxTotalRewards * questBudget.managementFee()) / 10_000; // 5% management fee
         uint256 questFactoryApprovalAmount = maxTotalRewards + maxProtocolReward + maxReferralReward;
+
+        uint256 maxManagementFee = (maxTotalRewards * questBudget.managementFee()) / 10_000;
         uint256 totalAllocationRequired = questFactoryApprovalAmount + maxManagementFee;
 
         // Approve questBudget to spend tokens
@@ -513,17 +537,17 @@ contract QuestBudgetTest is Test, TestUtils, IERC1155Receiver {
 
         vm.expectRevert("Insufficient funds for quest creation");
         questBudget.createERC20Quest(
-            1, // txHashChainId
-            address(mockERC20), // rewardTokenAddress
-            block.timestamp + 1 days, // endTime
-            block.timestamp, // startTime
-            totalParticipants, // totalParticipants
-            rewardAmount, // rewardAmount
-            "testQuest", // questId
-            "testAction", // actionType
-            "Test Quest", // questName
-            "Test Project", // projectName
-            referralRewardFee // referralRewardFee
+            txHashChainId_,
+            rewardTokenAddress_,
+            endTime_,
+            startTime_,
+            totalParticipants_,
+            rewardAmount_,
+            questId_,
+            actionType_,
+            questName_,
+            projectName_,
+            referralRewardFee_
         );
     }
 

--- a/test/QuestBudget.t.sol
+++ b/test/QuestBudget.t.sol
@@ -89,6 +89,11 @@ contract QuestBudgetTest is Test, TestUtils, IERC1155Receiver {
         assertEq(questBudget.available(address(mockERC1155), 42), 0);
     }
 
+    function test_InitialManagementFee() public {
+        // Ensure the management fee is 0
+        assertEq(questBudget.managementFee(), 0);
+    }
+
     function test_InitializerDisabled() public {
         // Because the slot is private, we use `vm.load` to access it then parse out the bits:
         //   - [0] is the `initializing` flag (which should be 0 == false)

--- a/test/QuestBudget.t.sol
+++ b/test/QuestBudget.t.sol
@@ -920,6 +920,27 @@ contract QuestBudgetTest is Test, TestUtils, IERC1155Receiver {
         assertEq(questBudget.available(address(otherMockERC20)), 0);
     }
 
+    function testAvailable_ReservedFunds() public {
+        // Mint some tokens to the questBudget
+        uint256 totalBalance = 100 ether;
+        mockERC20.mint(address(questBudget), totalBalance);
+
+        // Set reserved funds equal to total balance
+        uint256 reservedFunds = totalBalance;
+        bytes32 reservedFundsSlot = bytes32(uint256(6)); // reservedFunds is at slot 6
+        vm.store(address(questBudget), reservedFundsSlot, bytes32(reservedFunds));
+
+        uint256 availableBalance = questBudget.available(address(mockERC20));
+        assertEq(availableBalance, 0, "Available balance should be 0 when reserved funds equal total balance");
+
+        // Set reserved funds greater than total balance
+        reservedFunds = totalBalance + 1 wei;
+        vm.store(address(questBudget), reservedFundsSlot, bytes32(reservedFunds));
+
+        availableBalance = questBudget.available(address(mockERC20));
+        assertEq(availableBalance, 0, "Available balance should be 0 when reserved funds are > total balance");
+    }
+
     //////////////////////////////
     // QuestBudget.distributed //
     //////////////////////////////

--- a/test/QuestBudget.t.sol
+++ b/test/QuestBudget.t.sol
@@ -527,12 +527,12 @@ contract QuestBudgetTest is Test, TestUtils, IERC1155Receiver {
         );
     }
 
-    ///////////////////////////
+    ////////////////////////
     // QuestBudget.cancel //
-    ///////////////////////////
+    ////////////////////////
 
     function test_cancel() public {
-                // Define the parameters for the new quest
+        // Define the parameters for the new quest
         uint32 txHashChainId_ = 1;
         address rewardTokenAddress_ = address(mockERC20);
         uint256 endTime_ = block.timestamp + 1 days;

--- a/test/QuestBudget.t.sol
+++ b/test/QuestBudget.t.sol
@@ -1355,6 +1355,75 @@ contract QuestBudgetTest is Test, TestUtils, IERC1155Receiver {
         questBudget.payManagementFee(questId_);
     }
 
+    function testPayManagementFee_PartialParticipants() public {
+        // Set management fee
+        uint256 managementFeePercentage = 500; // 5%
+        vm.prank(questBudget.owner());
+        questBudget.setManagementFee(managementFeePercentage);
+
+        // Set quest data
+        uint32 txHashChainId_ = 1;
+        address rewardTokenAddress_ = address(mockERC20);
+        uint256 endTime_ = block.timestamp + 1 days;
+        uint256 startTime_ = block.timestamp;
+        uint256 totalParticipants_ = 100;
+        uint256 rewardAmount_ = 1 ether;
+        string memory questId_ = "testQuest";
+        string memory actionType_ = "testAction";
+        string memory questName_ = "Test Quest";
+        string memory projectName_ = "Test Project";
+        uint256 referralRewardFee_ = 250;
+        uint256 maxTotalRewards = totalParticipants_ * rewardAmount_;
+        uint256 questFee = uint256(mockQuestFactory.questFee());
+        uint256 referralRewardFee = uint256(mockQuestFactory.referralRewardFee());
+        uint256 maxProtocolReward = (maxTotalRewards * questFee) / 10_000;
+        uint256 maxReferralReward = (maxTotalRewards * referralRewardFee) / 10_000;
+        uint256 maxManagementFee = (maxTotalRewards * managementFeePercentage) / 10_000;
+        uint256 requiredApprovalAmount = maxTotalRewards + maxProtocolReward + maxReferralReward + maxManagementFee;
+
+        // Number of participants which is less than total
+        uint256 numberMinted_ = 75;
+
+        // Allocate tokens to questBudget
+        mockERC20.mint(address(questBudget), requiredApprovalAmount);
+
+        // Create quest
+        address questAddress = questBudget.createERC20Quest(
+            txHashChainId_, rewardTokenAddress_, endTime_, startTime_,
+            totalParticipants_, rewardAmount_, questId_, actionType_, questName_, projectName_, referralRewardFee_
+        );
+
+        // Mock quest data
+        mockQuestFactory.setQuestData(questId_, IQuestFactory.QuestData({
+            questAddress: questAddress,
+            rewardToken: address(mockERC20),
+            queued: false,
+            questFee: 250, // 2.5%
+            startTime: startTime_,
+            endTime: endTime_,
+            totalParticipants: totalParticipants_,
+            numberMinted: numberMinted_,
+            redeemedTokens: numberMinted_ * rewardAmount_,
+            rewardAmountOrTokenId: rewardAmount_,
+            hasWithdrawn: true
+        }));
+
+        // Calculate expected fee
+        uint256 expectedFeeToPay = (numberMinted_ * rewardAmount_ * managementFeePercentage) / 10_000;
+
+        // Get initial balance of the quest creator
+        uint256 initialBalance = mockERC20.balanceOf(address(this));
+
+        // Pay management fee
+        questBudget.payManagementFee(questId_);
+
+        // Get final balance of the quest creator
+        uint256 finalBalance = mockERC20.balanceOf(address(this));
+
+        // Verify the correct amount was transferred
+        assertEq(finalBalance - initialBalance, expectedFeeToPay, "Incorrect management fee paid");
+    }
+
     function testPayManagementFee_NotAuthorized() public {        
         vm.prank(address(0xc0ffee));
 

--- a/test/QuestBudget.t.sol
+++ b/test/QuestBudget.t.sol
@@ -1115,6 +1115,10 @@ contract QuestBudgetTest is Test, TestUtils, IERC1155Receiver {
         assertEq(questBudget.managementFee(), 500);
     }
 
+    //////////////////////////////////
+    // QuestBudget.payManagementFee //
+    //////////////////////////////////
+
     function testPayManagementFee() public {
         // Set management fee
         vm.prank(questBudget.owner());
@@ -1150,8 +1154,66 @@ contract QuestBudgetTest is Test, TestUtils, IERC1155Receiver {
             totalParticipants_, rewardAmount_, questId_, actionType_, questName_, projectName_, referralRewardFee_
         );
 
-        // Mock withdrawal
-        IQuestFactory.QuestData({
+        // Simulate valid quest data with hasWithdrawn set to true
+        mockQuestFactory.setQuestData(questId_, IQuestFactory.QuestData({
+            questAddress: questAddress,
+            rewardToken: address(mockERC20),
+            queued: false,
+            questFee: 250, // 2.5%
+            startTime: startTime_,
+            endTime: endTime_,
+            totalParticipants: totalParticipants_,
+            numberMinted: numberMinted_,
+            redeemedTokens: numberMinted_ * rewardAmount_,
+            rewardAmountOrTokenId: rewardAmount_,
+            hasWithdrawn: true
+        }));
+        uint256 initialBalance = mockERC20.balanceOf(address(this));
+
+        questBudget.payManagementFee(questId_);
+
+        uint256 finalBalance = mockERC20.balanceOf(address(this));
+
+        assertEq(finalBalance - initialBalance, 0.5 ether, "Incorrect management fee paid");
+    }
+
+    function testPayManagementFee_NotWithdrawn() public {
+        // Set management fee
+        vm.prank(questBudget.owner());
+        questBudget.setManagementFee(500); // 5%
+
+        // Set quest data
+        uint32 txHashChainId_ = 1;
+        address rewardTokenAddress_ = address(mockERC20);
+        uint256 endTime_ = block.timestamp + 1 days;
+        uint256 startTime_ = block.timestamp;
+        uint256 totalParticipants_ = 10;
+        uint256 rewardAmount_ = 1 ether;
+        string memory questId_ = "testQuest";
+        string memory actionType_ = "testAction";
+        string memory questName_ = "Test Quest";
+        string memory projectName_ = "Test Project";
+        uint256 referralRewardFee_ = 250;
+        uint256 numberMinted_ = 10;
+        uint256 maxTotalRewards = totalParticipants_ * rewardAmount_;
+        uint256 questFee = uint256(mockQuestFactory.questFee());
+        uint256 referralRewardFee = uint256(mockQuestFactory.referralRewardFee());
+        uint256 maxProtocolReward = (maxTotalRewards * questFee) / 10_000;
+        uint256 maxReferralReward = (maxTotalRewards * referralRewardFee) / 10_000;
+        uint256 maxManagementFee = (maxTotalRewards * questBudget.managementFee()) / 10_000;
+        uint256 requiredApprovalAmount = maxTotalRewards + maxProtocolReward + maxReferralReward + maxManagementFee;
+
+        // Allocate tokens to questBudget
+        mockERC20.mint(address(questBudget), requiredApprovalAmount);
+
+        // Create quest
+        address questAddress = questBudget.createERC20Quest(
+            txHashChainId_, rewardTokenAddress_, endTime_, startTime_,
+            totalParticipants_, rewardAmount_, questId_, actionType_, questName_, projectName_, referralRewardFee_
+        );
+
+        // Simulate quest data with hasWithdrawn set to false
+        mockQuestFactory.setQuestData(questId_, IQuestFactory.QuestData({
             questAddress: questAddress,
             rewardToken: address(mockERC20),
             queued: false,
@@ -1163,7 +1225,7 @@ contract QuestBudgetTest is Test, TestUtils, IERC1155Receiver {
             redeemedTokens: numberMinted_ * rewardAmount_,
             rewardAmountOrTokenId: rewardAmount_,
             hasWithdrawn: false
-        });
+        }));
 
         vm.expectRevert("Management fee cannot be claimed until the quest rewards are withdrawn");
         questBudget.payManagementFee(questId_);

--- a/test/QuestBudget.t.sol
+++ b/test/QuestBudget.t.sol
@@ -1099,8 +1099,11 @@ contract QuestBudgetTest is Test, TestUtils, IERC1155Receiver {
         vm.prank(questBudget.owner());
         questBudget.setManagementFee(500); // 5%
 
-        // Create quest with standard parameters (60 participants, 1 ETH reward per participant)
+        // Setup quest with standard parameters (60 participants, 1 ETH reward per participant)
         QuestSetupData memory data = setupQuestData();
+
+        // Simulate that the quest has already withdrawn
+        data.hasWithdrawn = true;
         createQuest(data, questBudget.owner());
 
         // Get balance after the quest has withdrawn
@@ -1128,7 +1131,6 @@ contract QuestBudgetTest is Test, TestUtils, IERC1155Receiver {
 
         // Create quest with standard parameters (60 participants, 1 ETH reward per participant)
         QuestSetupData memory data = setupQuestData();
-        data.hasWithdrawn = false;
         createQuest(data, questBudget.owner());
 
         vm.expectRevert("Management fee cannot be claimed until the quest rewards are withdrawn");
@@ -1163,8 +1165,11 @@ contract QuestBudgetTest is Test, TestUtils, IERC1155Receiver {
         vm.prank(questBudget.owner());
         questBudget.setManagementFee(500); // 5%
 
-        // Create quest with standard parameters (60 participants, 1 ETH reward per participant)
+        // Setup quest with standard parameters (60 participants, 1 ETH reward per participant)
         QuestSetupData memory data = setupQuestData();
+
+        // Simulate that the quest has already withdrawn
+        data.hasWithdrawn = true;
         createQuest(data, questBudget.owner());
 
         // Transfer 1 wei out of the budget
@@ -1184,6 +1189,9 @@ contract QuestBudgetTest is Test, TestUtils, IERC1155Receiver {
 
         // Setup quest with standard parameters (60 participants, 1 ETH reward per participant)
         QuestSetupData memory data = setupQuestData();
+
+        // Simulate that the quest has already withdrawn
+        data.hasWithdrawn = true;
 
         // Set number minted to 10 (instead of 60)
         data.numberMinted = 10;
@@ -1232,7 +1240,7 @@ contract QuestBudgetTest is Test, TestUtils, IERC1155Receiver {
             projectName: "Test Project",
             referralRewardFee: 250,
             numberMinted: 60,
-            hasWithdrawn: true
+            hasWithdrawn: false
         });
     }
 

--- a/test/QuestBudget.t.sol
+++ b/test/QuestBudget.t.sol
@@ -1231,6 +1231,13 @@ contract QuestBudgetTest is Test, TestUtils, IERC1155Receiver {
         questBudget.payManagementFee(questId_);
     }
 
+    function testPayManagementFee_NotAuthorized() public {        
+        vm.prank(address(0xc0ffee));
+
+        vm.expectRevert(BoostError.Unauthorized.selector);
+        questBudget.payManagementFee("testQuest");
+    }
+
     ///////////////////////////
     // Test Helper Functions //
     ///////////////////////////

--- a/test/QuestBudget.t.sol
+++ b/test/QuestBudget.t.sol
@@ -26,6 +26,7 @@ contract QuestBudgetTest is Test, TestUtils, IERC1155Receiver {
     QuestBudget questBudget;
 
     event QuestCancelled(address indexed questAddress, string questId, uint256 endsAt);
+    event ManagementFeePaid(string indexed questId, address indexed manager, uint256 amount);
 
     function setUp() public {
         address owner = address(this);
@@ -1088,6 +1089,60 @@ contract QuestBudgetTest is Test, TestUtils, IERC1155Receiver {
         
         // Assert that the management fee remains unchanged at 5%
         assertEq(questBudget.managementFee(), 500);
+    }
+
+    function testPayManagementFee() public {
+        // Set management fee
+        vm.prank(questBudget.owner());
+        questBudget.setManagementFee(500); // 5%
+
+        // Set quest data
+        uint32 txHashChainId_ = 1;
+        address rewardTokenAddress_ = address(mockERC20);
+        uint256 endTime_ = block.timestamp + 1 days;
+        uint256 startTime_ = block.timestamp;
+        uint256 totalParticipants_ = 10;
+        uint256 rewardAmount_ = 1 ether;
+        string memory questId_ = "testQuest";
+        string memory actionType_ = "testAction";
+        string memory questName_ = "Test Quest";
+        string memory projectName_ = "Test Project";
+        uint256 referralRewardFee_ = 250;
+        uint256 numberMinted_ = 10;
+        uint256 maxTotalRewards = totalParticipants_ * rewardAmount_;
+        uint256 questFee = uint256(mockQuestFactory.questFee());
+        uint256 referralRewardFee = uint256(mockQuestFactory.referralRewardFee());
+        uint256 maxProtocolReward = (maxTotalRewards * questFee) / 10_000;
+        uint256 maxReferralReward = (maxTotalRewards * referralRewardFee) / 10_000;
+        uint256 maxManagementFee = (maxTotalRewards * questBudget.managementFee()) / 10_000;
+        uint256 requiredApprovalAmount = maxTotalRewards + maxProtocolReward + maxReferralReward + maxManagementFee;
+
+        // Allocate tokens to questBudget
+        mockERC20.mint(address(questBudget), requiredApprovalAmount);
+
+        // Create quest
+        address questAddress = questBudget.createERC20Quest(
+            txHashChainId_, rewardTokenAddress_, endTime_, startTime_,
+            totalParticipants_, rewardAmount_, questId_, actionType_, questName_, projectName_, referralRewardFee_
+        );
+
+        // Mock withdrawal
+        IQuestFactory.QuestData({
+            questAddress: questAddress,
+            rewardToken: address(mockERC20),
+            queued: false,
+            questFee: 250, // 2.5%
+            startTime: startTime_,
+            endTime: endTime_,
+            totalParticipants: totalParticipants_,
+            numberMinted: numberMinted_,
+            redeemedTokens: numberMinted_ * rewardAmount_,
+            rewardAmountOrTokenId: rewardAmount_,
+            hasWithdrawn: false
+        });
+
+        vm.expectRevert("Management fee cannot be claimed until the quest rewards are withdrawn");
+        questBudget.payManagementFee(questId_);
     }
 
     ///////////////////////////

--- a/test/QuestBudget.t.sol
+++ b/test/QuestBudget.t.sol
@@ -480,8 +480,8 @@ contract QuestBudgetTest is Test, TestUtils, IERC1155Receiver {
         // Ensure the returned quest address is not the zero address
         assertTrue(questAddress != address(0));
 
-        // Assert that the quest manager is set to the test contract
-        assertEq(questBudget.questManagers(questId), address(this));
+        // Assert that the quest manager is set to the questBudget owner
+        assertEq(questBudget.questManagers(questId), address(questBudget.owner()));
 
         // Assert that the reserved funds is equal to the management fee
         assertEq(questBudget.reservedFunds(), maxManagementFee);

--- a/test/QuestBudget.t.sol
+++ b/test/QuestBudget.t.sol
@@ -1168,12 +1168,19 @@ contract QuestBudgetTest is Test, TestUtils, IERC1155Receiver {
             rewardAmountOrTokenId: rewardAmount_,
             hasWithdrawn: true
         }));
+
+        // Get balance after the quest has withdrawn
         uint256 initialBalance = mockERC20.balanceOf(address(this));
 
+        // Expect the ManagementFeePaid event to be emitted
+        vm.expectEmit();
+        emit ManagementFeePaid(questId_, address(this), maxManagementFee);
         questBudget.payManagementFee(questId_);
 
+        // Get balance after the management fee is paid
         uint256 finalBalance = mockERC20.balanceOf(address(this));
 
+        // Verify the correct amount was transferred
         assertEq(finalBalance - initialBalance, maxManagementFee, "Incorrect management fee paid");
     }
 

--- a/test/QuestBudget.t.sol
+++ b/test/QuestBudget.t.sol
@@ -1081,11 +1081,9 @@ contract QuestBudgetTest is Test, TestUtils, IERC1155Receiver {
         
         // Set an initial valid management fee (5%)
         questBudget.setManagementFee(500);
-        
-        // Expect the next transaction to revert with the specified error message
-        vm.expectRevert("Fee cannot exceed 100%");
-        
+
         // Attempt to set a management fee that exceeds 100%
+        vm.expectRevert("Fee cannot exceed 100%");
         questBudget.setManagementFee(10001);
         
         // Assert that the management fee remains unchanged at 5%

--- a/test/QuestBudget.t.sol
+++ b/test/QuestBudget.t.sol
@@ -25,6 +25,22 @@ contract QuestBudgetTest is Test, TestUtils, IERC1155Receiver {
     QuestFactoryMock mockQuestFactory;
     QuestBudget questBudget;
 
+    struct QuestSetupData {
+        uint32 txHashChainId;
+        address rewardTokenAddress;
+        uint256 endTime;
+        uint256 startTime;
+        uint256 totalParticipants;
+        uint256 rewardAmount;
+        string questId;
+        string actionType;
+        string questName;
+        string projectName;
+        uint256 referralRewardFee;
+        uint256 numberMinted;
+        bool hasWithdrawn;
+    }
+
     event QuestCancelled(address indexed questAddress, string questId, uint256 endsAt);
     event ManagementFeePaid(string indexed questId, address indexed manager, uint256 amount);
     event ManagementFeeSet(uint256 newFee);
@@ -379,20 +395,10 @@ contract QuestBudgetTest is Test, TestUtils, IERC1155Receiver {
     // QuestBudget.createERC20Quest //
     //////////////////////////////////
     function testCreateERC20Quest() public {
-        // Define the parameters for the new quest
-        uint32 txHashChainId_ = 1;
-        address rewardTokenAddress_ = address(mockERC20);
-        uint256 endTime_ = block.timestamp + 1 days;
-        uint256 startTime_ = block.timestamp;
-        uint256 totalParticipants_ = 10;
-        uint256 rewardAmount_ = 1 ether;
-        string memory questId_ = "testQuest";
-        string memory actionType_ = "testAction";
-        string memory questName_ = "Test Quest";
-        string memory projectName_ = "Test Project";
-        uint256 referralRewardFee_ = 250;
+        // Create quest with standard parameters (60 participants, 1 ETH reward per participant)
+        QuestSetupData memory data = setupQuestData();
         
-        uint256 maxTotalRewards = totalParticipants_ * rewardAmount_;
+        uint256 maxTotalRewards = data.totalParticipants * data.rewardAmount;
         uint256 questFee = uint256(mockQuestFactory.questFee());
         uint256 referralRewardFee = uint256(mockQuestFactory.referralRewardFee());
         uint256 maxProtocolReward = (maxTotalRewards * questFee) / 10_000;
@@ -408,24 +414,24 @@ contract QuestBudgetTest is Test, TestUtils, IERC1155Receiver {
 
         // Create the new quest
         address questAddress = questBudget.createERC20Quest(
-            txHashChainId_,
-            rewardTokenAddress_,
-            endTime_,
-            startTime_,
-            totalParticipants_,
-            rewardAmount_,
-            questId_,
-            actionType_,
-            questName_,
-            projectName_,
-            referralRewardFee_
+            data.txHashChainId,
+            data.rewardTokenAddress,
+            data.endTime,
+            data.startTime,
+            data.totalParticipants,
+            data.rewardAmount,
+            data.questId,
+            data.actionType,
+            data.questName,
+            data.projectName,
+            data.referralRewardFee
         );
 
         // Ensure the returned quest address is not the zero address
         assertTrue(questAddress != address(0));
 
         // Ensure the quest contract has the correct reward amount
-        assertEq(IERC20(rewardTokenAddress_).balanceOf(questAddress), approvalAmount);
+        assertEq(IERC20(data.rewardTokenAddress).balanceOf(questAddress), approvalAmount);
     }
 
     function testCreateERC20Quest_WithManagementFee() public {
@@ -433,20 +439,10 @@ contract QuestBudgetTest is Test, TestUtils, IERC1155Receiver {
         vm.prank(questBudget.owner());
         questBudget.setManagementFee(500); // 5%
 
-        // Define the parameters for the new quest
-        uint32 txHashChainId_ = 1;
-        address rewardTokenAddress_ = address(mockERC20);
-        uint256 endTime_ = block.timestamp + 1 days;
-        uint256 startTime_ = block.timestamp;
-        uint256 totalParticipants_ = 10;
-        uint256 rewardAmount_ = 1 ether;
-        string memory questId_ = "testQuest";
-        string memory actionType_ = "testAction";
-        string memory questName_ = "Test Quest";
-        string memory projectName_ = "Test Project";
-        uint256 referralRewardFee_ = 250;
+        // Create quest with standard parameters (60 participants, 1 ETH reward per participant)
+        QuestSetupData memory data = setupQuestData();
         
-        uint256 maxTotalRewards = totalParticipants_ * rewardAmount_;
+        uint256 maxTotalRewards = data.totalParticipants * data.rewardAmount;
         uint256 questFee = uint256(mockQuestFactory.questFee());
         uint256 referralRewardFee = uint256(mockQuestFactory.referralRewardFee());
         uint256 maxProtocolReward = (maxTotalRewards * questFee) / 10_000;
@@ -468,17 +464,17 @@ contract QuestBudgetTest is Test, TestUtils, IERC1155Receiver {
         // Create quest
         string memory questId = "testQuest";
         address questAddress = questBudget.createERC20Quest(
-            txHashChainId_,
-            rewardTokenAddress_,
-            endTime_,
-            startTime_,
-            totalParticipants_,
-            rewardAmount_,
-            questId_,
-            actionType_,
-            questName_,
-            projectName_,
-            referralRewardFee_
+            data.txHashChainId,
+            data.rewardTokenAddress,
+            data.endTime,
+            data.startTime,
+            data.totalParticipants,
+            data.rewardAmount,
+            data.questId,
+            data.actionType,
+            data.questName,
+            data.projectName,
+            data.referralRewardFee
         );
 
         // Ensure the returned quest address is not the zero address
@@ -505,20 +501,10 @@ contract QuestBudgetTest is Test, TestUtils, IERC1155Receiver {
         vm.prank(questBudget.owner());
         questBudget.setManagementFee(500); // 5%
     
-        // Define the parameters for the new quest
-        uint32 txHashChainId_ = 1;
-        address rewardTokenAddress_ = address(mockERC20);
-        uint256 endTime_ = block.timestamp + 1 days;
-        uint256 startTime_ = block.timestamp;
-        uint256 totalParticipants_ = 10;
-        uint256 rewardAmount_ = 1 ether;
-        string memory questId_ = "testQuest";
-        string memory actionType_ = "testAction";
-        string memory questName_ = "Test Quest";
-        string memory projectName_ = "Test Project";
-        uint256 referralRewardFee_ = 250;
+        // Setup quest with standard parameters (60 participants, 1 ETH reward per participant)
+        QuestSetupData memory data = setupQuestData();
         
-        uint256 maxTotalRewards = totalParticipants_ * rewardAmount_;
+        uint256 maxTotalRewards = data.totalParticipants * data.rewardAmount;
         uint256 questFee = uint256(mockQuestFactory.questFee());
         uint256 referralRewardFee = uint256(mockQuestFactory.referralRewardFee());
         uint256 maxProtocolReward = (maxTotalRewards * questFee) / 10_000;
@@ -538,17 +524,17 @@ contract QuestBudgetTest is Test, TestUtils, IERC1155Receiver {
 
         vm.expectRevert("Insufficient funds for quest creation");
         questBudget.createERC20Quest(
-            txHashChainId_,
-            rewardTokenAddress_,
-            endTime_,
-            startTime_,
-            totalParticipants_,
-            rewardAmount_,
-            questId_,
-            actionType_,
-            questName_,
-            projectName_,
-            referralRewardFee_
+            data.txHashChainId,
+            data.rewardTokenAddress,
+            data.endTime,
+            data.startTime,
+            data.totalParticipants,
+            data.rewardAmount,
+            data.questId,
+            data.actionType,
+            data.questName,
+            data.projectName,
+            data.referralRewardFee
         );
     }
 
@@ -557,52 +543,15 @@ contract QuestBudgetTest is Test, TestUtils, IERC1155Receiver {
     ////////////////////////
 
     function test_cancel() public {
-        // Define the parameters for the new quest
-        uint32 txHashChainId_ = 1;
-        address rewardTokenAddress_ = address(mockERC20);
-        uint256 endTime_ = block.timestamp + 1 days;
-        uint256 startTime_ = block.timestamp;
-        uint256 totalParticipants_ = 10;
-        uint256 rewardAmount_ = 1 ether;
-        string memory questId_ = "testQuest";
-        string memory actionType_ = "testAction";
-        string memory questName_ = "Test Quest";
-        string memory projectName_ = "Test Project";
-        uint256 referralRewardFee_ = 250;
-
-        uint256 maxTotalRewards = totalParticipants_ * rewardAmount_;
-        uint256 questFee = uint256(mockQuestFactory.questFee());
-        uint256 referralRewardFee = uint256(mockQuestFactory.referralRewardFee());
-        uint256 maxProtocolReward = (maxTotalRewards * questFee) / 10_000;
-        uint256 maxReferralReward = (maxTotalRewards * referralRewardFee) / 10_000;
-        uint256 approvalAmount = maxTotalRewards + maxProtocolReward + maxReferralReward;
-        mockERC20.mint(address(this), approvalAmount);
-        // Ensure the budget has enough tokens for the reward
-        mockERC20.approve(address(questBudget), approvalAmount);
-        bytes memory allocateBytes = _makeFungibleTransfer(Budget.AssetType.ERC20, address(mockERC20), address(this), approvalAmount);
-        questBudget.allocate(allocateBytes);
-        console.logBytes(allocateBytes);
-
-        // Create the new quest
-        address questAddress = questBudget.createERC20Quest(
-            txHashChainId_,
-            rewardTokenAddress_,
-            endTime_,
-            startTime_,
-            totalParticipants_,
-            rewardAmount_,
-            questId_,
-            actionType_,
-            questName_,
-            projectName_,
-            referralRewardFee_
-        );
+        // Create quest with standard parameters (60 participants, 1 ETH reward per participant)
+        QuestSetupData memory data = setupQuestData();
+        address questAddress = createQuest(data, questBudget.owner());
 
         // Ensure the returned quest address is not the zero address
         assertTrue(questAddress != address(0));
 
-        // Ensure the quest contract has the correct reward amount
-        assertEq(IERC20(rewardTokenAddress_).balanceOf(questAddress), approvalAmount);
+        // Ensure the quest contract has a positive balance
+        assertGt(IERC20(data.rewardTokenAddress).balanceOf(questAddress), 0);
 
         vm.expectEmit();
 
@@ -1150,64 +1099,26 @@ contract QuestBudgetTest is Test, TestUtils, IERC1155Receiver {
         vm.prank(questBudget.owner());
         questBudget.setManagementFee(500); // 5%
 
-        // Set quest data
-        uint32 txHashChainId_ = 1;
-        address rewardTokenAddress_ = address(mockERC20);
-        uint256 endTime_ = block.timestamp + 1 days;
-        uint256 startTime_ = block.timestamp;
-        uint256 totalParticipants_ = 10;
-        uint256 rewardAmount_ = 1 ether;
-        string memory questId_ = "testQuest";
-        string memory actionType_ = "testAction";
-        string memory questName_ = "Test Quest";
-        string memory projectName_ = "Test Project";
-        uint256 referralRewardFee_ = 250;
-        uint256 numberMinted_ = 10;
-        uint256 maxTotalRewards = totalParticipants_ * rewardAmount_;
-        uint256 questFee = uint256(mockQuestFactory.questFee());
-        uint256 referralRewardFee = uint256(mockQuestFactory.referralRewardFee());
-        uint256 maxProtocolReward = (maxTotalRewards * questFee) / 10_000;
-        uint256 maxReferralReward = (maxTotalRewards * referralRewardFee) / 10_000;
-        uint256 maxManagementFee = (maxTotalRewards * questBudget.managementFee()) / 10_000;
-        uint256 requiredApprovalAmount = maxTotalRewards + maxProtocolReward + maxReferralReward + maxManagementFee;
-
-        // Allocate tokens to questBudget
-        mockERC20.mint(address(questBudget), requiredApprovalAmount);
-
-        // Create quest
-        address questAddress = questBudget.createERC20Quest(
-            txHashChainId_, rewardTokenAddress_, endTime_, startTime_,
-            totalParticipants_, rewardAmount_, questId_, actionType_, questName_, projectName_, referralRewardFee_
-        );
-
-        // Simulate valid quest data with hasWithdrawn set to true
-        mockQuestFactory.setQuestData(questId_, IQuestFactory.QuestData({
-            questAddress: questAddress,
-            rewardToken: address(mockERC20),
-            queued: false,
-            questFee: 250, // 2.5%
-            startTime: startTime_,
-            endTime: endTime_,
-            totalParticipants: totalParticipants_,
-            numberMinted: numberMinted_,
-            redeemedTokens: numberMinted_ * rewardAmount_,
-            rewardAmountOrTokenId: rewardAmount_,
-            hasWithdrawn: true
-        }));
+        // Create quest with standard parameters (60 participants, 1 ETH reward per participant)
+        QuestSetupData memory data = setupQuestData();
+        createQuest(data, questBudget.owner());
 
         // Get balance after the quest has withdrawn
         uint256 initialBalance = mockERC20.balanceOf(address(this));
 
+        // Calculate expected fee
+        uint256 expectedFeeToPay = (data.numberMinted * data.rewardAmount * questBudget.managementFee()) / 10_000;
+
         // Expect the ManagementFeePaid event to be emitted
         vm.expectEmit();
-        emit ManagementFeePaid(questId_, address(this), maxManagementFee);
-        questBudget.payManagementFee(questId_);
+        emit ManagementFeePaid(data.questId, address(this), expectedFeeToPay);
+        questBudget.payManagementFee(data.questId);
 
         // Get balance after the management fee is paid
         uint256 finalBalance = mockERC20.balanceOf(address(this));
 
         // Verify the correct amount was transferred
-        assertEq(finalBalance - initialBalance, maxManagementFee, "Incorrect management fee paid");
+        assertEq(finalBalance - initialBalance, expectedFeeToPay, "Incorrect management fee paid");
     }
 
     function testPayManagementFee_NotWithdrawn() public {
@@ -1215,53 +1126,13 @@ contract QuestBudgetTest is Test, TestUtils, IERC1155Receiver {
         vm.prank(questBudget.owner());
         questBudget.setManagementFee(500); // 5%
 
-        // Set quest data
-        uint32 txHashChainId_ = 1;
-        address rewardTokenAddress_ = address(mockERC20);
-        uint256 endTime_ = block.timestamp + 1 days;
-        uint256 startTime_ = block.timestamp;
-        uint256 totalParticipants_ = 10;
-        uint256 rewardAmount_ = 1 ether;
-        string memory questId_ = "testQuest";
-        string memory actionType_ = "testAction";
-        string memory questName_ = "Test Quest";
-        string memory projectName_ = "Test Project";
-        uint256 referralRewardFee_ = 250;
-        uint256 numberMinted_ = 10;
-        uint256 maxTotalRewards = totalParticipants_ * rewardAmount_;
-        uint256 questFee = uint256(mockQuestFactory.questFee());
-        uint256 referralRewardFee = uint256(mockQuestFactory.referralRewardFee());
-        uint256 maxProtocolReward = (maxTotalRewards * questFee) / 10_000;
-        uint256 maxReferralReward = (maxTotalRewards * referralRewardFee) / 10_000;
-        uint256 maxManagementFee = (maxTotalRewards * questBudget.managementFee()) / 10_000;
-        uint256 requiredApprovalAmount = maxTotalRewards + maxProtocolReward + maxReferralReward + maxManagementFee;
-
-        // Allocate tokens to questBudget
-        mockERC20.mint(address(questBudget), requiredApprovalAmount);
-
-        // Create quest
-        address questAddress = questBudget.createERC20Quest(
-            txHashChainId_, rewardTokenAddress_, endTime_, startTime_,
-            totalParticipants_, rewardAmount_, questId_, actionType_, questName_, projectName_, referralRewardFee_
-        );
-
-        // Simulate quest data with hasWithdrawn set to false
-        mockQuestFactory.setQuestData(questId_, IQuestFactory.QuestData({
-            questAddress: questAddress,
-            rewardToken: address(mockERC20),
-            queued: false,
-            questFee: 250, // 2.5%
-            startTime: startTime_,
-            endTime: endTime_,
-            totalParticipants: totalParticipants_,
-            numberMinted: numberMinted_,
-            redeemedTokens: numberMinted_ * rewardAmount_,
-            rewardAmountOrTokenId: rewardAmount_,
-            hasWithdrawn: false
-        }));
+        // Create quest with standard parameters (60 participants, 1 ETH reward per participant)
+        QuestSetupData memory data = setupQuestData();
+        data.hasWithdrawn = false;
+        createQuest(data, questBudget.owner());
 
         vm.expectRevert("Management fee cannot be claimed until the quest rewards are withdrawn");
-        questBudget.payManagementFee(questId_);
+        questBudget.payManagementFee(data.questId);
     }
 
     function testPayManagementFee_NotQuestCreator() public {
@@ -1277,56 +1148,14 @@ contract QuestBudgetTest is Test, TestUtils, IERC1155Receiver {
         authorized[0] = true;
         questBudget.setAuthorized(accounts, authorized);
 
-        // Set quest data
-        uint32 txHashChainId_ = 1;
-        address rewardTokenAddress_ = address(mockERC20);
-        uint256 endTime_ = block.timestamp + 1 days;
-        uint256 startTime_ = block.timestamp;
-        uint256 totalParticipants_ = 10;
-        uint256 rewardAmount_ = 1 ether;
-        string memory questId_ = "testQuest";
-        string memory actionType_ = "testAction";
-        string memory questName_ = "Test Quest";
-        string memory projectName_ = "Test Project";
-        uint256 referralRewardFee_ = 250;
-        uint256 numberMinted_ = 10;
-        uint256 maxTotalRewards = totalParticipants_ * rewardAmount_;
-        uint256 questFee = uint256(mockQuestFactory.questFee());
-        uint256 referralRewardFee = uint256(mockQuestFactory.referralRewardFee());
-        uint256 maxProtocolReward = (maxTotalRewards * questFee) / 10_000;
-        uint256 maxReferralReward = (maxTotalRewards * referralRewardFee) / 10_000;
-        uint256 maxManagementFee = (maxTotalRewards * questBudget.managementFee()) / 10_000;
-        uint256 requiredApprovalAmount = maxTotalRewards + maxProtocolReward + maxReferralReward + maxManagementFee;
-
-        // Allocate tokens to questBudget
-        mockERC20.mint(address(questBudget), requiredApprovalAmount);
-
-        // Create quest using authorized address
-        vm.prank(questCreator);
-        address questAddress = questBudget.createERC20Quest(
-            txHashChainId_, rewardTokenAddress_, endTime_, startTime_,
-            totalParticipants_, rewardAmount_, questId_, actionType_, questName_, projectName_, referralRewardFee_
-        );
-
-        // Mock quest data
-        mockQuestFactory.setQuestData(questId_, IQuestFactory.QuestData({
-            questAddress: questAddress,
-            rewardToken: address(mockERC20),
-            queued: false,
-            questFee: 250, // 2.5%
-            startTime: startTime_,
-            endTime: endTime_,
-            totalParticipants: totalParticipants_,
-            numberMinted: numberMinted_,
-            redeemedTokens: numberMinted_ * rewardAmount_,
-            rewardAmountOrTokenId: rewardAmount_,
-            hasWithdrawn: true
-        }));
+        // Create quest with standard parameters (60 participants, 1 ETH reward per participant)
+        QuestSetupData memory data = setupQuestData();
+        createQuest(data, questCreator);
 
         // Attempt to call payManagementFee as budget owner (not quest creator)
         vm.prank(questBudget.owner());
         vm.expectRevert("Only the quest creator can claim the management fee");
-        questBudget.payManagementFee(questId_);
+        questBudget.payManagementFee(data.questId);
     }
 
     function testPayManagementFee_InsufficientFunds() public {
@@ -1334,50 +1163,9 @@ contract QuestBudgetTest is Test, TestUtils, IERC1155Receiver {
         vm.prank(questBudget.owner());
         questBudget.setManagementFee(500); // 5%
 
-        // Set quest data
-        uint32 txHashChainId_ = 1;
-        address rewardTokenAddress_ = address(mockERC20);
-        uint256 endTime_ = block.timestamp + 1 days;
-        uint256 startTime_ = block.timestamp;
-        uint256 totalParticipants_ = 10;
-        uint256 rewardAmount_ = 1 ether;
-        string memory questId_ = "testQuest";
-        string memory actionType_ = "testAction";
-        string memory questName_ = "Test Quest";
-        string memory projectName_ = "Test Project";
-        uint256 referralRewardFee_ = 250;
-        uint256 numberMinted_ = 10;
-        uint256 maxTotalRewards = totalParticipants_ * rewardAmount_;
-        uint256 questFee = uint256(mockQuestFactory.questFee());
-        uint256 referralRewardFee = uint256(mockQuestFactory.referralRewardFee());
-        uint256 maxProtocolReward = (maxTotalRewards * questFee) / 10_000;
-        uint256 maxReferralReward = (maxTotalRewards * referralRewardFee) / 10_000;
-        uint256 maxManagementFee = (maxTotalRewards * questBudget.managementFee()) / 10_000;
-        uint256 requiredApprovalAmount = maxTotalRewards + maxProtocolReward + maxReferralReward + maxManagementFee;
-
-        // Allocate tokens to questBudget, but less than required
-        mockERC20.mint(address(questBudget), requiredApprovalAmount);
-
-        // Create quest
-        address questAddress = questBudget.createERC20Quest(
-            txHashChainId_, rewardTokenAddress_, endTime_, startTime_,
-            totalParticipants_, rewardAmount_, questId_, actionType_, questName_, projectName_, referralRewardFee_
-        );
-
-        // Mock quest data
-        mockQuestFactory.setQuestData(questId_, IQuestFactory.QuestData({
-            questAddress: questAddress,
-            rewardToken: address(mockERC20),
-            queued: false,
-            questFee: 250, // 2.5%
-            startTime: startTime_,
-            endTime: endTime_,
-            totalParticipants: totalParticipants_,
-            numberMinted: numberMinted_,
-            redeemedTokens: numberMinted_ * rewardAmount_,
-            rewardAmountOrTokenId: rewardAmount_,
-            hasWithdrawn: true
-        }));
+        // Create quest with standard parameters (60 participants, 1 ETH reward per participant)
+        QuestSetupData memory data = setupQuestData();
+        createQuest(data, questBudget.owner());
 
         // Transfer 1 wei out of the budget
         vm.prank(address(questBudget));
@@ -1385,7 +1173,7 @@ contract QuestBudgetTest is Test, TestUtils, IERC1155Receiver {
 
         // Attempt to pay management fee with insufficient funds
         vm.expectRevert("Insufficient funds to pay management fee");
-        questBudget.payManagementFee(questId_);
+        questBudget.payManagementFee(data.questId);
     }
 
     function testPayManagementFee_PartialParticipants() public {
@@ -1394,61 +1182,23 @@ contract QuestBudgetTest is Test, TestUtils, IERC1155Receiver {
         vm.prank(questBudget.owner());
         questBudget.setManagementFee(managementFeePercentage);
 
-        // Set quest data
-        uint32 txHashChainId_ = 1;
-        address rewardTokenAddress_ = address(mockERC20);
-        uint256 endTime_ = block.timestamp + 1 days;
-        uint256 startTime_ = block.timestamp;
-        uint256 totalParticipants_ = 100;
-        uint256 rewardAmount_ = 1 ether;
-        string memory questId_ = "testQuest";
-        string memory actionType_ = "testAction";
-        string memory questName_ = "Test Quest";
-        string memory projectName_ = "Test Project";
-        uint256 referralRewardFee_ = 250;
-        uint256 maxTotalRewards = totalParticipants_ * rewardAmount_;
-        uint256 questFee = uint256(mockQuestFactory.questFee());
-        uint256 referralRewardFee = uint256(mockQuestFactory.referralRewardFee());
-        uint256 maxProtocolReward = (maxTotalRewards * questFee) / 10_000;
-        uint256 maxReferralReward = (maxTotalRewards * referralRewardFee) / 10_000;
-        uint256 maxManagementFee = (maxTotalRewards * managementFeePercentage) / 10_000;
-        uint256 requiredApprovalAmount = maxTotalRewards + maxProtocolReward + maxReferralReward + maxManagementFee;
+        // Setup quest with standard parameters (60 participants, 1 ETH reward per participant)
+        QuestSetupData memory data = setupQuestData();
 
-        // Number of participants which is less than total
-        uint256 numberMinted_ = 75;
-
-        // Allocate tokens to questBudget
-        mockERC20.mint(address(questBudget), requiredApprovalAmount);
+        // Set number minted to 10 (instead of 60)
+        data.numberMinted = 10;
 
         // Create quest
-        address questAddress = questBudget.createERC20Quest(
-            txHashChainId_, rewardTokenAddress_, endTime_, startTime_,
-            totalParticipants_, rewardAmount_, questId_, actionType_, questName_, projectName_, referralRewardFee_
-        );
-
-        // Mock quest data
-        mockQuestFactory.setQuestData(questId_, IQuestFactory.QuestData({
-            questAddress: questAddress,
-            rewardToken: address(mockERC20),
-            queued: false,
-            questFee: 250, // 2.5%
-            startTime: startTime_,
-            endTime: endTime_,
-            totalParticipants: totalParticipants_,
-            numberMinted: numberMinted_,
-            redeemedTokens: numberMinted_ * rewardAmount_,
-            rewardAmountOrTokenId: rewardAmount_,
-            hasWithdrawn: true
-        }));
+        createQuest(data, questBudget.owner());
 
         // Calculate expected fee
-        uint256 expectedFeeToPay = (numberMinted_ * rewardAmount_ * managementFeePercentage) / 10_000;
+        uint256 expectedFeeToPay = (data.numberMinted * data.rewardAmount * managementFeePercentage) / 10_000;
 
         // Get initial balance of the quest creator
         uint256 initialBalance = mockERC20.balanceOf(address(this));
 
         // Pay management fee
-        questBudget.payManagementFee(questId_);
+        questBudget.payManagementFee(data.questId);
 
         // Get final balance of the quest creator
         uint256 finalBalance = mockERC20.balanceOf(address(this));
@@ -1467,6 +1217,70 @@ contract QuestBudgetTest is Test, TestUtils, IERC1155Receiver {
     ///////////////////////////
     // Test Helper Functions //
     ///////////////////////////
+
+    function setupQuestData() internal view returns (QuestSetupData memory) {
+        return QuestSetupData({
+            txHashChainId: 1,
+            rewardTokenAddress: address(mockERC20),
+            endTime: block.timestamp + 1 days,
+            startTime: block.timestamp,
+            totalParticipants: 60,
+            rewardAmount: 1 ether,
+            questId: "testQuest",
+            actionType: "testAction",
+            questName: "Test Quest",
+            projectName: "Test Project",
+            referralRewardFee: 250,
+            numberMinted: 60,
+            hasWithdrawn: true
+        });
+    }
+
+    function createQuest(QuestSetupData memory data, address questCreator) internal returns (address questAddress) {
+        uint256 maxTotalRewards = data.totalParticipants * data.rewardAmount;
+        uint256 questFee = uint256(mockQuestFactory.questFee());
+        uint256 referralRewardFee = uint256(mockQuestFactory.referralRewardFee());
+        uint256 maxProtocolReward = (maxTotalRewards * questFee) / 10_000;
+        uint256 maxReferralReward = (maxTotalRewards * referralRewardFee) / 10_000;
+        uint256 maxManagementFee = (maxTotalRewards * questBudget.managementFee()) / 10_000;
+        uint256 requiredApprovalAmount = maxTotalRewards + maxProtocolReward + maxReferralReward + maxManagementFee;
+
+        // Allocate tokens to questBudget
+        mockERC20.mint(address(questBudget), requiredApprovalAmount);
+
+        // Create quest
+        vm.prank(questCreator);
+        questAddress = questBudget.createERC20Quest(
+            data.txHashChainId,
+            data.rewardTokenAddress,
+            data.endTime,
+            data.startTime,
+            data.totalParticipants,
+            data.rewardAmount,
+            data.questId,
+            data.actionType,
+            data.questName,
+            data.projectName,
+            data.referralRewardFee
+        );
+
+        // Mock quest data
+        mockQuestFactory.setQuestData(data.questId, IQuestFactory.QuestData({
+            questAddress: questAddress,
+            rewardToken: data.rewardTokenAddress,
+            queued: false,
+            questFee: 250, // 2.5%
+            startTime: data.startTime,
+            endTime: data.endTime,
+            totalParticipants: data.totalParticipants,
+            numberMinted: data.numberMinted,
+            redeemedTokens: data.numberMinted * data.rewardAmount,
+            rewardAmountOrTokenId: data.rewardAmount,
+            hasWithdrawn: data.hasWithdrawn
+        }));
+
+        return questAddress;
+    }
 
     function _makeFungibleTransfer(Budget.AssetType assetType, address asset, address target, uint256 value)
         internal

--- a/test/QuestBudget.t.sol
+++ b/test/QuestBudget.t.sol
@@ -438,9 +438,9 @@ contract QuestBudgetTest is Test, TestUtils, IERC1155Receiver {
         uint256 referralRewardFee = 250; // 2.5%
         uint256 maxProtocolReward = (maxTotalRewards * questFee) / 10_000;
         uint256 maxReferralReward = (maxTotalRewards * referralRewardFee) / 10_000;
-        uint256 managementFee = (maxTotalRewards * 500) / 10_000; // 5% management fee
+        uint256 maxManagementFee = (maxTotalRewards * questBudget.managementFee()) / 10_000; // 5% management fee
         uint256 questFactoryApprovalAmount = maxTotalRewards + maxProtocolReward + maxReferralReward;
-        uint256 totalAllocationRequired = questFactoryApprovalAmount + managementFee;
+        uint256 totalAllocationRequired = questFactoryApprovalAmount + maxManagementFee;
 
         // Approve questBudget to spend tokens
         mockERC20.approve(address(questBudget), totalAllocationRequired);
@@ -473,10 +473,10 @@ contract QuestBudgetTest is Test, TestUtils, IERC1155Receiver {
         assertEq(questBudget.questManagers(questId), address(this));
 
         // Assert that the reserved funds is equal to the management fee
-        assertEq(questBudget.reservedFunds(), managementFee);
+        assertEq(questBudget.reservedFunds(), maxManagementFee);
 
         // Calculate the expected available balance
-        uint256 expectedAvailable = totalAllocationRequired - questFactoryApprovalAmount - managementFee;
+        uint256 expectedAvailable = totalAllocationRequired - questFactoryApprovalAmount - maxManagementFee;
 
         // Assert that the available balance is 0
         assertEq(expectedAvailable, 0);
@@ -498,16 +498,16 @@ contract QuestBudgetTest is Test, TestUtils, IERC1155Receiver {
         uint256 referralRewardFee = 250; // 2.5%
         uint256 maxProtocolReward = (maxTotalRewards * questFee) / 10_000;
         uint256 maxReferralReward = (maxTotalRewards * referralRewardFee) / 10_000;
-        uint256 managementFee = (maxTotalRewards * 500) / 10_000; // 5% management fee
+        uint256 maxManagementFee = (maxTotalRewards * questBudget.managementFee()) / 10_000; // 5% management fee
         uint256 questFactoryApprovalAmount = maxTotalRewards + maxProtocolReward + maxReferralReward;
-        uint256 totalAllocationRequired = questFactoryApprovalAmount + managementFee;
+        uint256 totalAllocationRequired = questFactoryApprovalAmount + maxManagementFee;
 
         // Approve questBudget to spend tokens
         mockERC20.approve(address(questBudget), totalAllocationRequired);
 
         // Allocate the needed amount minus the management fee
         questBudget.allocate(
-            _makeFungibleTransfer(Budget.AssetType.ERC20, address(mockERC20), address(this), totalAllocationRequired - managementFee)
+            _makeFungibleTransfer(Budget.AssetType.ERC20, address(mockERC20), address(this), totalAllocationRequired - maxManagementFee)
         );
 
         vm.expectRevert("Insufficient funds for quest creation");

--- a/test/QuestBudget.t.sol
+++ b/test/QuestBudget.t.sol
@@ -27,6 +27,7 @@ contract QuestBudgetTest is Test, TestUtils, IERC1155Receiver {
 
     event QuestCancelled(address indexed questAddress, string questId, uint256 endsAt);
     event ManagementFeePaid(string indexed questId, address indexed manager, uint256 amount);
+    event ManagementFeeSet(uint256 newFee);
 
     function setUp() public {
         address owner = address(this);
@@ -1092,6 +1093,10 @@ contract QuestBudgetTest is Test, TestUtils, IERC1155Receiver {
     function testSetManagementFee() public {
         // Simulate a transaction from the owner of the questBudget contract
         vm.prank(questBudget.owner());
+
+        // Expect the ManagementFeeSet event to be emitted
+        vm.expectEmit();
+        emit ManagementFeeSet(500);
 
         // Call the setManagementFee function with a value of 5%
         questBudget.setManagementFee(500);

--- a/test/mocks/QuestFactoryMock.sol
+++ b/test/mocks/QuestFactoryMock.sol
@@ -112,6 +112,11 @@ contract QuestFactoryMock {
         emit QuestCancelled(address(this), questId_, 0);
     }
 
+    // test helper function to set mock quest data
+    function setQuestData(string memory questId, IQuestFactory.QuestData memory data) public {
+        questDataMap[questId] = data;
+    }
+
     function questData(string memory questId) public view returns (IQuestFactory.QuestData memory) {
         return questDataMap[questId];
     }

--- a/test/mocks/QuestFactoryMock.sol
+++ b/test/mocks/QuestFactoryMock.sol
@@ -3,6 +3,8 @@ pragma solidity 0.8.19;
 
 import {IERC20} from "openzeppelin-contracts/token/ERC20/IERC20.sol";
 
+import {IQuestFactory} from "../../contracts/interfaces/IQuestFactory.sol";
+
 contract QuestFactoryMock {
     uint256 numberMinted;
     uint256 public mintFee;
@@ -22,7 +24,9 @@ contract QuestFactoryMock {
         uint256 referralRewardFee;
     }
 
-    QuestData public questData;
+    QuestData public _questData;
+
+    mapping(string => IQuestFactory.QuestData) public questDataMap;
 
     event MintFeePaid(
         string questId,
@@ -82,7 +86,7 @@ contract QuestFactoryMock {
         uint256 maxProtocolReward = (maxTotalRewards * this.questFee()) / 10_000;
         uint256 maxReferralReward = (maxTotalRewards * this.referralRewardFee()) / 10_000;
         uint256 approvalAmount = maxTotalRewards + maxProtocolReward + maxReferralReward;
-        questData = QuestData({
+        _questData = QuestData({
             txHashChainId: txHashChainId_,
             rewardTokenAddress: rewardTokenAddress_,
             endTime: endTime_,
@@ -108,4 +112,7 @@ contract QuestFactoryMock {
         emit QuestCancelled(address(this), questId_, 0);
     }
 
+    function questData(string memory questId) public view returns (IQuestFactory.QuestData memory) {
+        return questDataMap[questId];
+    }
 }


### PR DESCRIPTION
# Management Fee Implementation for QuestBudget

## Overview
This PR implements the management fee feature for the QuestBudget contract, allowing boost creators to earn a fee for managing boosts.

## Key Changes

1. **Management Fee Setting**: 
   - Added `setManagementFee` function to allow the contract owner to set the management fee percentage.
   - Implemented `managementFee` state variable to store the fee percentage.

2. **Boost Creation with Management Fee**:
   - Modified `createERC20Quest` to calculate and reserve the management fee during quest creation.
   - Added `reservedFunds` state variable to track funds reserved for management fees.
   - Updated `available` function to account for reserved funds.

3. **Management Fee Payment**:
   - Implemented `payManagementFee` function to allow boost creators to claim their management fee after completion.
   - Added checks to ensure only the boost creator can claim the fee and only after the remaining rewards have been withdrawn.

4. **Manager Tracking**:
   - Added `questManagers` mapping to associate quest IDs with their creators' addresses.

5. **Events**:
   - Added `ManagementFeeSet` event for logging changes to the management fee percentage.
   - Added `ManagementFeePaid` event for logging management fee payments.

6. **Testing**:
   - Implemented comprehensive test suite for new management fee functionality.
   - Added helper functions and structs to streamline quest creation using common parameters.

## Implementation Details

- The management fee is set in basis points (e.g., 500 = 5%).
- The maximum management fee that can be set is 10000 (100%)
- The fee is calculated based on the actual number of participants rather than the total possible participants.
- Reserved funds are tracked separately to ensure accurate reporting of available funds.
- Safeguards are in place to prevent unauthorized fee claims and to handle edge cases like insufficient funds.

## Security Considerations

- The `setManagementFee` function is restricted to the contract owner.
- The `payManagementFee` function includes checks to prevent unauthorized claims.
- The contract uses OpenZeppelin's `SafeERC20` for secure token transfers.

## Testing

- Setting and updating the management fee
- Creating quests with management fees
- Paying out management fees under various scenarios
- Edge cases such as insufficient funds and unauthorized access attempts